### PR TITLE
Restyle the Pages landing page and point README readers to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Written in [Idris2](https://github.com/idris-lang/Idris2).
 See `docs/NovaFoundation.txt` for the theory, `docs/NovaPipeline.txt`
 for the architecture, `docs/NovaElaboration.txt` for the surface
 syntax and elaborator, and `docs/NovaKernel.txt` for the kernel rules.
+Browse the rendered specs and syntax-highlighted `src/nova/*.nova`
+sources online at [russoul.github.io/Nova](https://russoul.github.io/Nova/).
 
 ### Dependencies
 

--- a/tools/pages-index.html
+++ b/tools/pages-index.html
@@ -3,12 +3,83 @@
 <head>
 <meta charset="utf-8">
 <title>Nova</title>
+<style>
+/* Palette matches tools/render-specs.py's CSS and tools/nova-docs.css,
+   so all three rendered pages read as one system. */
+:root {
+  --paper:#f7f8fa; --ink:#20242d; --faint:#5c6472; --hair:#d8dce2;
+  --panel:#eef0f4; --tos:#0e7c86; --nova:#2f5fc0; --meta:#7862a8;
+  --link:#0e7c86; --gold:#92700c; --natc:#b03a70;
+}
+@media (prefers-color-scheme: dark) { :root {
+  --paper:#191b20; --ink:#dcdee4; --faint:#9aa1ae; --hair:#33373f;
+  --panel:#20232a; --tos:#53cad4; --nova:#82a5ea; --meta:#a995d6;
+  --link:#53cad4; --gold:#d8b45e; --natc:#e592bb;
+}}
+:root[data-theme="dark"] {
+  --paper:#191b20; --ink:#dcdee4; --faint:#9aa1ae; --hair:#33373f;
+  --panel:#20232a; --tos:#53cad4; --nova:#82a5ea; --meta:#a995d6;
+  --link:#53cad4; --gold:#d8b45e; --natc:#e592bb;
+}
+:root[data-theme="light"] {
+  --paper:#f7f8fa; --ink:#20242d; --faint:#5c6472; --hair:#d8dce2;
+  --panel:#eef0f4; --tos:#0e7c86; --nova:#2f5fc0; --meta:#7862a8;
+  --link:#0e7c86; --gold:#92700c; --natc:#b03a70;
+}
+* { box-sizing:border-box; }
+body {
+  margin:0 auto; max-width:640px; padding:3rem 1.25rem 4rem;
+  background:var(--paper); color:var(--ink);
+  font-family:"Iowan Old Style","Palatino Linotype",Palatino,"Book Antiqua",Georgia,serif;
+  font-size:17px; line-height:1.55;
+}
+h1 { font-size:2rem; margin:0 0 .3rem; letter-spacing:.02em; }
+h1 .nova { color:var(--nova); }
+.tagline { color:var(--faint); margin:0 0 2.2rem; }
+.tagline code {
+  font-family:ui-monospace,"SF Mono",Menlo,Consolas,monospace; font-size:.85em;
+}
+.cards { display:flex; flex-direction:column; gap:1rem; }
+.card {
+  display:block; padding:1.1rem 1.3rem; border:1px solid var(--hair);
+  border-left:4px solid var(--card-accent, var(--nova)); border-radius:6px;
+  background:var(--panel); text-decoration:none; color:inherit;
+}
+.card:hover { border-color:var(--card-accent, var(--nova)); }
+.card h2 {
+  margin:0 0 .25rem; font-size:1.05rem;
+  font-family:ui-sans-serif,system-ui,sans-serif; color:var(--card-accent, var(--nova));
+}
+.card p { margin:0; color:var(--faint); font-size:.95rem; }
+#specs { --card-accent: var(--gold); }
+#sources { --card-accent: var(--tos); }
+footer {
+  margin-top:2.5rem; font-family:ui-sans-serif,system-ui,sans-serif;
+  font-size:13px; color:var(--faint);
+}
+footer a { color:var(--link); }
+</style>
 </head>
 <body>
-<h1>Nova</h1>
-<ul>
-<li><a href="specs.html">Theory specs</a> — NovaFoundation, NovaSyntax, NovaModel, NovaKernel, NovaElaboration, NovaPipeline</li>
-<li><a href="nova/index.html">Nova sources</a> — src/nova/*.nova, syntax-highlighted via the LSP's own semantic tokens</li>
-</ul>
+<h1><span class="nova">Nova</span></h1>
+<p class="tagline">
+  A mechanised formal type theory based on extensional Martin&ndash;Löf
+  type theory, checked by an elaborator/kernel pipeline: surface files
+  elaborate to certificate-carrying artifacts that a small trusted
+  kernel re-checks.
+</p>
+<div class="cards">
+  <a class="card" id="specs" href="specs.html">
+    <h2>Theory specs</h2>
+    <p>NovaFoundation, NovaSyntax, NovaModel, NovaKernel, NovaElaboration, NovaPipeline &mdash; the rules, rendered.</p>
+  </a>
+  <a class="card" id="sources" href="nova/index.html">
+    <h2>Nova sources</h2>
+    <p><code>src/nova/*.nova</code>, syntax-highlighted via the same semantic tokens the LSP sends an editor.</p>
+  </a>
+</div>
+<footer>
+  <a href="https://github.com/Russoul/Nova">Source on GitHub</a>
+</footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- `tools/pages-index.html`: the landing page now shares the palette/typography already established by the rendered specs page (`render-specs.py`) and the rendered Nova-source pages (`nova-docs.css`) instead of a bare link list — same color tokens (light/dark), same serif body type, two accented cards (gold for specs, teal for sources) matching each destination's own internal accent color.
- `README.md`: points readers to the deployed docs at https://russoul.github.io/Nova/.