### PR TITLE
Defining equations: the clausal def item

### DIFF
--- a/docs/NovaElaboration.txt
+++ b/docs/NovaElaboration.txt
@@ -62,6 +62,10 @@ term/type grammar below is self-contained.
 file  ::= import* (item | fixity)*
 imp   ::= import M | import M (n (, n)*)
 item  ::= def  n : T{≥0} ≔ t{≥0}
+        | def  n : T{≥0}                      # a DECLARATION — a def
+                                              #   without a definiens,
+                                              #   a NAMED RIGID HOLE;
+                                              #   see e-decl in Items
         | type x ≔ T{≥0}
         | data ([x : T{≥0}])* ( n : Q (; n : Q)* )
                                               # a QIIT signature literal —

--- a/docs/NovaElaboration.txt
+++ b/docs/NovaElaboration.txt
@@ -53,7 +53,8 @@ term/type grammar below is self-contained.
 # A file is a sequence of items. `def` introduces a term definition,
 # `type` a type definition — the two signature-entry forms of
 # Foundation's Σ; `data` is an ITEM MACRO that expands into a batch
-# of them (QIIT section below). Every item is declared in the EMPTY context:
+# of them (QIIT section below), and a def with CLAUSES is likewise an
+# item macro (Defining equations section below). Every item is declared in the EMPTY context:
 # parameters are ordinary Π-binders in the item's type (the iterated
 # binder syntax below keeps that pleasant), and a reference to an
 # item is a bare name. Foundation's Σ entries keep their general
@@ -73,6 +74,33 @@ item  ::= def  n : T{≥0} ≔ t{≥0}
                                               #   ambient PARAMETER
                                               #   telescope, see the QIIT
                                               #   section below
+        | def  n : T{≥0} ([n])? (≔ t{≥0})? clause+
+                                              # a def with DEFINING
+                                              #   EQUATIONS — an ITEM
+                                              #   MACRO; the optional [n]
+                                              #   names the uniqueness
+                                              #   lemma, the optional
+                                              #   definiens is the WITNESS
+                                              #   form. See the Defining
+                                              #   equations section below
+clause ::= | lhs ≔ t{≥0} ([n])?               # each clause OPENS with the
+                                              #   marker |, RESERVED for
+                                              #   this role; the optional
+                                              #   [n] names the clause's
+                                              #   equation lemma
+lhs    ::= n pat* | pat op pat                # the head is the item's own
+                                              #   name (infix use needs a
+                                              #   fixity, as anywhere);
+                                              #   parsed as an ordinary
+                                              #   application spelling and
+                                              #   REREAD as patterns
+pat    ::= x | Z | S pat | inj₁ pat | inj₂ pat | (pat)
+                                              # constructor spellings and
+                                              #   variables, any depth —
+                                              #   the FRAGMENT demands
+                                              #   depth 1, the grammar
+                                              #   does not (`_` in any
+                                              #   binder, as everywhere)
 fixity ::= infixl d op | infixr d op          # d a digit 0-9
 
 # Q is the ToS type grammar of a data entry — Foundation's qiit-types
@@ -98,8 +126,9 @@ fixity ::= infixl d op | infixr d op          # d a digit 0-9
 # the name, and the name is the operator (binary applications of
 # operator-shaped names lay out infix, fully parenthesized).
 # Operator tokens are maximal runs of the operator alphabet
-#   + - * < > = & | ! ? % ^ ~ @ # ⊕ ⊗ ⊙ ⊞ ⊟ ∙ ∘ · ≤ ≥ ∸ ⧺ ⊥ ⊤ ∧ ∨ ⊃ ¬ ↔
-# (the reserved theory tokens → ⨯ ≡ ∈ ≔ / . , : are excluded, and the
+#   + - * < > = & ! ? % ^ ~ @ # ⊕ ⊗ ⊙ ⊞ ⊟ ∙ ∘ · ≤ ≥ ∸ ⧺ ⊥ ⊤ ∧ ∨ ⊃ ¬ ↔
+# (the reserved theory tokens → ⨯ ≡ ∈ ≔ / . , : are excluded — and so
+# is |, the clause marker of the clausal def item — and the
 # lexer eats "--" as a comment, so no operator contains it). The
 # mention form (op) — e.g. (+) — is the operator as an ordinary
 # reference, usable anywhere an atom is; local binders are never
@@ -1081,6 +1110,208 @@ the swap by computation — e-star turns it into an ordinary obligation
 otherwise — or as a reference to a proven lemma. Nothing about
 obligations, discharge or the report is QIIT-aware.
 
+//////////// Defining equations: the clausal def item /////////////
+
+A def with CLAUSES is an ITEM MACRO, data's sibling. The item
+
+  def plus : ℕ → ℕ → ℕ
+    | plus Z n     ≔ n
+    | plus (S m) n ≔ S (plus m n)
+
+asserts that its equations DETERMINE the definiendum — that the space
+of solutions
+
+  (ρ : ℕ → ℕ → ℕ) ⨯ ((n : ℕ) → ρ Z n ≡ n ∈ ℕ)
+                  ⨯ ((m : ℕ) (n : ℕ) → ρ (S m) n ≡ S (ρ m n) ∈ ℕ)
+
+is CONTRACTIBLE (has an element, and any two of its elements are
+equal — the iso-to-𝟙 reading) — and expands into a batch of ordinary
+defs naming the three pieces of that assertion. The macro itself adds
+nothing to Σ; nothing about obligations, discharge, modules or the
+report is clause-aware; no Foundation rule and no kernel capability
+is added.
+
+  def plus  : ℕ → ℕ → ℕ                                    # EXISTENCE
+            ≔ λm. ℕ-elim (x. ℕ → ℕ) (λn. n) (k ih. λn. S (ih n)) m
+  def plusZ : (n : ℕ) → plus Z n ≡ n ∈ ℕ                   # the CLAUSES,
+            ≔ λn. ⋆                                        #   Π-closed
+  def plusS : (m : ℕ) (n : ℕ) → plus (S m) n ≡ S (plus m n) ∈ ℕ
+            ≔ λm. λn. ⋆
+  def plusEta :                                            # UNIQUENESS
+        (g : ℕ → ℕ → ℕ)
+      → (hz : (n : ℕ) → g Z n ≡ n ∈ ℕ)
+      → (hs : (m : ℕ) (n : ℕ) → g (S m) n ≡ S (g m n) ∈ ℕ)
+      → (m : ℕ) (n : ℕ) → g m n ≡ plus m n ∈ ℕ
+      ≔ λg. λhz. λhs. λm.
+          ℕ-elim (x. (n : ℕ) → g x n ≡ plus x n ∈ ℕ)
+                 (λn. ⋆) (k ih. λn. ⋆) m
+
+In general, for  def f : (x₁ : A₁) → … → (xₖ : Aₖ) → B  with clauses
+f p̄ᵢ ≔ tᵢ, the batch is
+
+  def f    : (x₁ : A₁) → … → (xₖ : Aₖ) → B ≔ ρ
+  def nᵢ   : Π(Γᵢ). f p̄ᵢ ≡ tᵢ ∈ B[p̄ᵢ] ≔ λ…. ⋆
+             # Γᵢ the PATTERN TELESCOPE: the columns in order, the
+             # split column contributing its constructor's argument
+             # (nothing at Z); recursive occurrences in tᵢ stay
+             # REFERENCES to f
+  def nEta : (g : (x₁ : A₁) → … → (xₖ : Aₖ) → B)
+           → (h₁ : Π(Γ₁). g p̄₁ ≡ t₁[g/f] ∈ B[p̄₁]) → …
+           → (x₁ : A₁) → … → (xₖ : Aₖ)
+           → g x₁ … xₖ ≡ f x₁ … xₖ ∈ B
+
+Read the batch as the definition's INTERFACE: the equations are the
+definition, ρ is an implementation detail. On every later item and
+run the clause lemmas are ACCEPTED LEMMAS of E, so a conversion
+touching f at a constructor discharges by a ONE-STEP match against
+them — no unfolding of f through the eliminator, no fuel spent — the
+"make the trace directly matchable" remedy (docs/NovaPipeline.txt)
+pre-applied. nEta is the recursor's universal property as a store
+entry: stated POINTWISE (its trailing binders are determined by the
+equation's sides — no function-type equality needed), its g-clause
+premises are equality-typed parameters the sides do not determine,
+i.e. SIDE CONDITIONS in E's documented sense — to prove g ≐ f
+pointwise, exhibit that g satisfies the clauses.
+
+# SURFACE FORM. Clause LHSs are parsed as ordinary application (or
+# infix) spellings headed by the item's own name and REREAD as
+# patterns: every argument position must be a variable or a
+# constructor pattern — Z, S p, inj₁ p, inj₂ p, any depth, possibly
+# parenthesized; all clauses spell the same number k ≥ 1 of
+# positions, covering the leading k columns of the item's type
+# (Π's past the k-th stay inside B — the generated equations then
+# sit at a Π-type, which ≡ embeds like any other). Any other LHS
+# spelling is a structural error — missing structure, not a failed
+# equation (the dividing line of Judgement forms). The clause
+# separator is ≔, as at def: a clause IS a definiens, given
+# pointwise (`=` remains an ordinary operator token). The marker |
+# is RESERVED — withdrawn from the operator alphabet — because a
+# clause may directly follow the witness form's definiens, where an
+# infix reading would capture it.
+
+# NAMES. The expansion mints Σ names; the reproducibility invariant
+# demands they be a pure function of the source. For an
+# identifier-named item n the defaults append the split
+# constructor's tag — nZ, nS at an ℕ split; nInl, nInr at a ⊎ split
+# (subscripts are not identifier characters); nEq for the no-split
+# form — and nEta for uniqueness. A trailing [m] on a clause
+# overrides its lemma's name; [m] on the header (after the type)
+# overrides the uniqueness name. An OPERATOR-named item has no
+# identifier to prefix: every clause and the header must carry the
+# override, a structural error otherwise —
+#
+#   infixl 6 +
+#   def + : ℕ → ℕ → ℕ [plusEta]
+#     | Z + n   ≔ n [plusZ]
+#     | S m + n ≔ S (m + n) [plusS]
+#
+# Generated names enter Σ like any other entry (duplicates are the
+# usual structural error).
+
+# THE STRUCTURAL FRAGMENT — the clause shapes the splitter compiles:
+#   * exactly one column j bears constructor patterns across the
+#     clauses (the SPLIT COLUMN) — every other position is a
+#     variable in every clause, and each clause's LHS variables are
+#     DISTINCT (linear patterns). No split column is permitted iff
+#     there is a single clause (the NO-SPLIT form).
+#   * whnf(Aⱼ) is ℕ and the split patterns are exactly Z and S m
+#     (each once, either order), or whnf(Aⱼ) is a ⊎ and they are
+#     exactly inj₁ a and inj₂ b (El-decodings included — ty-el-nat,
+#     ty-el-sum).
+#   * recursion is STRUCTURAL: f does not occur in the Z / inj₁ /
+#     inj₂ / no-split bodies, and each of its occurrences in the
+#     S-clause body heads an application of at least j arguments
+#     whose first j−1 are the clause's own column variables and
+#     whose j-th is the predecessor m. Arguments PAST the split
+#     column are arbitrary terms — the Π-motive below quantifies
+#     over the trailing columns, so recursion at a changed later
+#     argument is in the fragment.
+# Fragment membership is syntactic, hence deterministic — which tier
+# below fires is a pure function of the source.
+
+# SYNTHESIS (ℕ at column j shown; ⊎ is the same shape minus
+# recursion; the no-split form is λ-abstraction alone). The witness
+# eliminates the split variable at the motive that Π-CLOSES the
+# trailing columns — they may depend on it, and the closure is what
+# makes the induction hypothesis a FUNCTION over them:
+#
+#   ρ ≔ λx₁. … λxⱼ.
+#         ℕ-elim (x. (xⱼ₊₁ : Aⱼ₊₁[x]) → … → (xₖ : Aₖ[x]) → B[x])
+#                (λxⱼ₊₁. … λxₖ. t_Z′)
+#                (m ih. λxⱼ₊₁. … λxₖ. t_S′)
+#                xⱼ
+#
+# t_C′ is the clause body with its variables mapped to the
+# corresponding binders and every recursive call f x₁ … xⱼ₋₁ m ē
+# replaced (innermost first) by ih ē. The clause-lemma bodies are
+# λ…. ⋆: unfolding f (el-sig-beta) and one β step land both sides of
+# each clause on a common normal form, so e-star's equation
+# discharges by computation — obligation-free, replayed by the
+# kernel as ordinary beta finals.
+#
+# The nEta body is the same eliminator at the pointwise EQUALITY
+# motive, both cases ⋆ (the plusEta shape above, Π-closure of the
+# trailing columns included; the no-split form needs no eliminator —
+# its body is λ…. ⋆ outright). This is deliberate: el-nat-eta,
+# el-sum-eta, el-qiit-eta have NO kernel replay finals
+# (docs/NovaKernel.txt, caveat A5) and need none — the generated
+# proof is A5's route, an ordinary eliminator lemma at an equality
+# motive. Its ⋆'s discharge from E with no new mechanism: each
+# case's goal rewrites by the matching g-clause hypothesis (an
+# ambient equality hypothesis, peeled, parametric), by ih at the
+# recursive positions — parametric in the trailing columns exactly
+# because the motive Π-closed them — and by the CLAUSE LEMMAS on the
+# f side (they precede nEta in the batch, so they are in E; no
+# unfolding of ρ is ever needed, which also makes the proof
+# independent of where ρ came from). The same silent-induction
+# pipeline as every ℕ-elim proof; if the engine ever misses, the
+# residue is an ordinary obligation, never a wrong acceptance.
+
+# OUTSIDE THE FRAGMENT (deeper patterns, another split type, several
+# split columns, a missing or duplicated constructor, non-structural
+# recursion) the item DEGRADES; it never walls:
+#   * WITH a witness — def f : T ≔ t | clauses — the splitter is
+#     skipped: f is an ordinary def with definiens t, and the clause
+#     lemmas are emitted with bodies λ…. ⋆. Each ⋆ that does not
+#     discharge is an ordinary obligation, sited at the clausal item
+#     under the generated lemma's name (e-star: stated exactly where
+#     the user claimed it); the remedy is the standard
+#     prepend-a-lemma-and-rerun. nEta's body is still SYNTHESIZED
+#     whenever the clauses are fragment-shaped — the eta induction
+#     needs only the clause lemmas, not ρ's provenance — and is
+#     λ…. ⋆ otherwise, surfacing the uniqueness statement as one
+#     obligation.
+#   * WITHOUT a witness the whole batch demotes to DECLARATIONS
+#     (e-decl): f, the clause lemmas and nEta enter Σ as named rigid
+#     holes. The clause lemmas — Prf-of-≡ under Π's — register in
+#     the lemma store as declared equations (the abstract-interface
+#     idiom of e-decl), so everything downstream elaborates against
+#     the interface; acceptance is blocked by the holes, and the
+#     remedy is a witness (≔ t) or clauses reshaped into the
+#     fragment.
+# Three tiers, one semantics: in the fragment the elaborator proves
+# everything; witness-tier the user supplies existence and proves
+# the equations; declaration-tier the file merely ASSERTS the
+# interface. What the item MEANS never changes — only who does the
+# work.
+
+# ADEQUACY. For an in-fragment item Foundation derives, over the
+# accepted Σ: each clause equation for ρ (el-sig-beta plus one β
+# step), and the uniqueness statement — nEta is el-nat-eta /
+# el-sum-eta internalized through Prf and reflection, and the
+# generated proof RE-DERIVES it rather than citing it, which is why
+# the kernel needs no η finals. Together the two halves say the
+# solution space is contractible and the item denotes ITS unique
+# inhabitant. A missing case loses uniqueness, contradictory
+# overlapping clauses lose existence — coverage and consistency are
+# SEMANTIC here, obligations rather than checkers — and no clause
+# set needs a termination argument, now or ever: everything compiles
+# to eliminators, and totality is the theory's.
+
+# DEFERRED extensions are enumerated in Future work; each is a new
+# way to fill the same three artifact slots — new synthesis tactics,
+# never new semantics.
+
 //////////// Modules /////////////
 
 A MODULE is a file; a dotted module name resolves against the root
@@ -1226,3 +1457,12 @@ Two corollaries worth keeping in view while implementing:
   type/element positions (today a QIIT is reachable only through a
   data item's generated names); indexed sorts of LARGE signatures
   (unnameable in the closed-item discipline).
+* Clausal defs beyond the structural fragment (Defining equations
+  section; each item fills the same three artifact slots): nested
+  patterns and multi-column splits (split trees); QIIT splits —
+  point-only signatures first, quotiented sorts demanding
+  per-clause-pair well-definedness after; COPATTERN clauses
+  (out (f x̄) ≔ …) compiling to corec, uniqueness by el-nu-coind
+  with the graph invariant as the bisimulation; strong induction /
+  course-of-values as an alternative existence synthesis; mutual
+  blocks as a single QIIT elimination problem.

--- a/docs/NovaElaboration.txt
+++ b/docs/NovaElaboration.txt
@@ -1266,6 +1266,17 @@ pointwise, exhibit that g satisfies the clauses.
 # independent of where ρ came from). The same silent-induction
 # pipeline as every ℕ-elim proof; if the engine ever misses, the
 # residue is an ordinary obligation, never a wrong acceptance.
+#
+# One such miss is CURRENT, recorded by a golden test
+# (elab-clauses-eta-obligation): a recursive call NESTED under
+# another application — mul's  plus n (mul m n)  — puts the
+# ih-rewrite inside an argument of a stuck eliminator spine, a
+# position whose expected type equation replay's typed descent
+# cannot yet determine (the constant-motive approximation,
+# docs/NovaPipeline.txt "Status"). The definition and its clause
+# lemmas still accept; only the uniqueness ⋆ stands, as an ordinary
+# obligation. Widening the descent — the argument position's type is
+# the head's synthesizable domain — is engine/kernel future work.
 
 # OUTSIDE THE FRAGMENT (deeper patterns, another split type, several
 # split columns, a missing or duplicated constructor, non-structural
@@ -1465,4 +1476,7 @@ Two corollaries worth keeping in view while implementing:
   (out (f x̄) ≔ …) compiling to corec, uniqueness by el-nu-coind
   with the graph invariant as the bisimulation; strong induction /
   course-of-values as an alternative existence synthesis; mutual
-  blocks as a single QIIT elimination problem.
+  blocks as a single QIIT elimination problem. ENGINE: typed descent
+  through neutral-application arguments, so a NESTED recursive call
+  (mul-shape) discharges its uniqueness ⋆ — today that ⋆ stands as
+  an ordinary obligation (elab-clauses-eta-obligation).

--- a/nova-docs.ipkg
+++ b/nova-docs.ipkg
@@ -15,6 +15,7 @@ modules = Nova.Kernel.Syntax
         , Nova.Elaboration.Named
         , Nova.Elaboration
         , Nova.Elaboration.Surface
+        , Nova.Elaboration.Clauses
         , Nova.Elaboration.Parser
         , Nova.Elaboration.Loader
         , Nova.Kernel.Parser

--- a/nova-tests.ipkg
+++ b/nova-tests.ipkg
@@ -13,6 +13,7 @@ modules = Nova.Kernel.Syntax
         , Nova.Kernel.Parser
         , Nova.Elaboration
         , Nova.Elaboration.Surface
+        , Nova.Elaboration.Clauses
         , Nova.Elaboration.Parser
         , Nova.Elaboration.Loader
 

--- a/nova.ipkg
+++ b/nova.ipkg
@@ -15,6 +15,7 @@ modules = Nova.Kernel.Syntax
         , Nova.Elaboration.Named
         , Nova.Elaboration
         , Nova.Elaboration.Surface
+        , Nova.Elaboration.Clauses
         , Nova.Elaboration.Parser
         , Nova.Elaboration.Loader
         , Nova.Kernel.Parser

--- a/src/idris/Nova/Elaboration.idr
+++ b/src/idris/Nova/Elaboration.idr
@@ -50,6 +50,7 @@ import Me.Russoul.Text.Position
 import Me.Russoul.Text.Range
 import Nova.Elaboration.Named
 import Nova.Elaboration.Surface
+import Nova.Elaboration.Clauses
 import Nova.Elaboration.Parser
 
 %default covering
@@ -4042,6 +4043,24 @@ elabItemGo (SData params decls) = do
     upto : Nat -> List Nat
     upto Z = []
     upto (S n) = upto n ++ [n]
+
+elabItemGo (SClausalDef nrng x ty etaName witness clauses) = do
+  -- a def with DEFINING EQUATIONS (docs/NovaElaboration.txt,
+  -- "Defining equations"): an ITEM MACRO. The expansion is pure
+  -- surface-level synthesis (Nova.Elaboration.Clauses); the batch —
+  -- the definition, the Π-closed clause lemmas, the uniqueness
+  -- lemma — elaborates through the ordinary item pipeline, so
+  -- obligations, lemma registration, kernel checking and the report
+  -- need no clause awareness at all. A Left is a STRUCTURAL error;
+  -- everything non-structural degrades inside the expansion (witness
+  -- tier / declaration tier) rather than failing.
+  census <- openCensus
+  case expandClausal nrng x ty etaName witness clauses of
+    Left err => throw "def \{x}: \{err}"
+    Right (MkExpansion items echo) => do
+      ignore $ traverse elabItemGo items
+      suffix <- opensSuffix census
+      pure (echo ++ suffix)
 
 -- ===== Report =====
 

--- a/src/idris/Nova/Elaboration/Clauses.idr
+++ b/src/idris/Nova/Elaboration/Clauses.idr
@@ -1,0 +1,838 @@
+module Nova.Elaboration.Clauses
+
+-- The clausal def ITEM MACRO (docs/NovaElaboration.txt, "Defining
+-- equations"): fragment analysis and expansion into a batch of
+-- ordinary surface items, elaborated by the ordinary item pipeline
+-- in Nova.Elaboration — which is where discharge, obligations,
+-- certificates, lemma registration and the report all happen. No
+-- Foundation rule and no kernel capability is involved.
+--
+-- The expansion names the three pieces of the contractibility
+-- contract:
+--   * EXISTENCE — def f ≔ ρ: a synthesized eliminator body (the
+--     structural fragment), the user's witness, or a declaration;
+--   * one Π-CLOSED EQUATION LEMMA per clause, body λ…. ⋆ —
+--     discharged by pure computation in the fragment, an ordinary
+--     obligation otherwise;
+--   * UNIQUENESS — nEta, stated POINTWISE, its body the eliminator
+--     at the equality motive whenever the clauses are
+--     fragment-shaped (the A5 route, docs/NovaKernel.txt: η rules
+--     have no kernel finals and need none), a bare λ…. ⋆ otherwise.
+--
+-- Everything below is pure surface-level term surgery. The generated
+-- items reference each other by Σ-name, so batch ORDER is semantic:
+-- the definition first, the clause lemmas next (their ⋆-bodies
+-- unfold f), the uniqueness lemma last (its ⋆-cases rewrite by the
+-- clause lemmas — never by unfolding ρ, which keeps eta synthesis
+-- independent of where the witness came from).
+
+import Data.List
+import Data.Maybe
+import Data.SnocList
+import Data.String
+
+import Me.Russoul.Text.Range
+
+import Nova.Elaboration.Named
+import Nova.Elaboration.Surface
+
+%default covering
+
+-- ===== Surface de Bruijn surgery =====
+--
+-- The expansion rebuilds user subterms (column types, clause RHSs)
+-- under binder stacks the user never wrote: lemma telescopes and
+-- eliminator motives/cases. All of it is index remapping over the
+-- indexed surface AST; signature references are names and pass
+-- through untouched (except where a traversal deliberately targets
+-- them — replaceSig below).
+
+mutual
+  mapRefsE : (onVar : Nat -> Maybe Range -> String -> Nat -> SElem) ->
+             (onSig : Nat -> Maybe Range -> String -> SElem) ->
+             Nat -> SElem -> SElem
+  mapRefsE f g d (SVar r n i) = if i < d then SVar r n i else f d r n i
+  mapRefsE f g d (SSig r x) = g d r x
+  mapRefsE f g d SUnitI = SUnitI
+  mapRefsE f g d SZeroN = SZeroN
+  mapRefsE f g d (SSuc t) = SSuc (mapRefsE f g d t)
+  mapRefsE f g d (SLam x t) = SLam x (mapRefsE f g (S d) t)
+  mapRefsE f g d (SLet x e b) = SLet x (mapRefsE f g d e) (mapRefsE f g (S (S d)) b)
+  mapRefsE f g d (SApp h e) = SApp (mapRefsE f g d h) (mapRefsE f g d e)
+  mapRefsE f g d (SPair a b) = SPair (mapRefsE f g d a) (mapRefsE f g d b)
+  mapRefsE f g d (SProj1 t) = SProj1 (mapRefsE f g d t)
+  mapRefsE f g d (SProj2 t) = SProj2 (mapRefsE f g d t)
+  mapRefsE f g d SZeroC = SZeroC
+  mapRefsE f g d SOneC = SOneC
+  mapRefsE f g d SNatC = SNatC
+  mapRefsE f g d (SPiC x a b) = SPiC x (mapRefsE f g d a) (mapRefsE f g (S d) b)
+  mapRefsE f g d (SSigmaC x a b) = SSigmaC x (mapRefsE f g d a) (mapRefsE f g (S d) b)
+  mapRefsE f g d (SSumC a b) = SSumC (mapRefsE f g d a) (mapRefsE f g d b)
+  mapRefsE f g d (SQuotC a x y r) = SQuotC (mapRefsE f g d a) x y (mapRefsE f g (S (S d)) r)
+  mapRefsE f g d (SEqC l r t) = SEqC (mapRefsE f g d l) (mapRefsE f g d r) (mapRefsTy f g d t)
+  mapRefsE f g d (SZeroElim t) = SZeroElim (mapRefsE f g d t)
+  mapRefsE f g d (SNatElim n mot z n2 ih s t) =
+    SNatElim n (mapRefsTy f g (S d) mot) (mapRefsE f g d z) n2 ih
+             (mapRefsE f g (S (S d)) s) (mapRefsE f g d t)
+  mapRefsE f g d (SInj1 t) = SInj1 (mapRefsE f g d t)
+  mapRefsE f g d (SInj2 t) = SInj2 (mapRefsE f g d t)
+  mapRefsE f g d (SSumElim z mot a l b r t) =
+    SSumElim z (mapRefsTy f g (S d) mot) a (mapRefsE f g (S d) l) b
+             (mapRefsE f g (S d) r) (mapRefsE f g d t)
+  mapRefsE f g d (SClass t) = SClass (mapRefsE f g d t)
+  mapRefsE f g d (SQuotElim z mot a h q) =
+    SQuotElim z (mapRefsTy f g (S d) mot) a (mapRefsE f g (S d) h) (mapRefsE f g d q)
+  mapRefsE f g d (SNuC p) = SNuC (mapRefsP f g d p)
+  mapRefsE f g d (SOut e) = SOut (mapRefsE f g d e)
+  mapRefsE f g d (SCorec x a h u) =
+    SCorec x (mapRefsE f g d a) (mapRefsE f g (S d) h) (mapRefsE f g d u)
+  mapRefsE f g d (SCoind nx ny r pw mx my mh q) =
+    SCoind nx ny (mapRefsE f g (S (S d)) r) (mapRefsE f g d pw) mx my mh
+           (mapRefsE f g (S (S (S d))) q)
+  mapRefsE f g d (SSquash t) = SSquash (mapRefsTy f g d t)
+  mapRefsE f g d SStar = SStar
+  mapRefsE f g d (SStarWit e) = SStarWit (mapRefsE f g d e)
+  mapRefsE f g d (SSquashElim e x body) =
+    SSquashElim (mapRefsE f g d e) x (mapRefsE f g (S d) body)
+  mapRefsE f g d (SAnn e ty) = SAnn (mapRefsE f g d e) (mapRefsTy f g d ty)
+  mapRefsE f g d (SHole r s x) = SHole r s x
+
+  mapRefsTy : (onVar : Nat -> Maybe Range -> String -> Nat -> SElem) ->
+              (onSig : Nat -> Maybe Range -> String -> SElem) ->
+              Nat -> STy -> STy
+  mapRefsTy f g d STyZero = STyZero
+  mapRefsTy f g d STyOne = STyOne
+  mapRefsTy f g d STyNat = STyNat
+  mapRefsTy f g d STyUniv = STyUniv
+  mapRefsTy f g d (STySig x) = STySig x
+  mapRefsTy f g d (STyPi x a b) = STyPi x (mapRefsTy f g d a) (mapRefsTy f g (S d) b)
+  mapRefsTy f g d (STySigma x a b) = STySigma x (mapRefsTy f g d a) (mapRefsTy f g (S d) b)
+  mapRefsTy f g d (STySum a b) = STySum (mapRefsTy f g d a) (mapRefsTy f g d b)
+  mapRefsTy f g d (STyQuot a x y r) = STyQuot (mapRefsTy f g d a) x y (mapRefsE f g (S (S d)) r)
+  mapRefsTy f g d (STyEq l r t) = STyEq (mapRefsE f g d l) (mapRefsE f g d r) (mapRefsTy f g d t)
+  mapRefsTy f g d (STyEl e) = STyEl (mapRefsE f g d e)
+  mapRefsTy f g d STyProp = STyProp
+  mapRefsTy f g d (STyPrf e) = STyPrf (mapRefsE f g d e)
+  mapRefsTy f g d (STyNu p) = STyNu (mapRefsP f g d p)
+  mapRefsTy f g d (STyHole r s x) = STyHole r s x
+
+  mapRefsP : (onVar : Nat -> Maybe Range -> String -> Nat -> SElem) ->
+             (onSig : Nat -> Maybe Range -> String -> SElem) ->
+             Nat -> SPoly -> SPoly
+  mapRefsP f g d SPHole = SPHole
+  mapRefsP f g d (SPConst a) = SPConst (mapRefsE f g d a)
+  mapRefsP f g d (SPProd p q) = SPProd (mapRefsP f g d p) (mapRefsP f g d q)
+  mapRefsP f g d (SPSum p q) = SPSum (mapRefsP f g d p) (mapRefsP f g d q)
+  mapRefsP f g d (SPSigma x a p) = SPSigma x (mapRefsE f g d a) (mapRefsP f g (S d) p)
+  mapRefsP f g d (SPPi x a p) = SPPi x (mapRefsE f g d a) (mapRefsP f g (S d) p)
+
+keepSig : Nat -> Maybe Range -> String -> SElem
+keepSig _ r x = SSig r x
+
+||| Add `amt` to every free variable whose top-level index is ≥ cutoff.
+shiftE : (cutoff, amt : Nat) -> SElem -> SElem
+shiftE c a = mapRefsE (\d, r, n, i => if i >= d + c then SVar r n (i + a) else SVar r n i) keepSig 0
+
+shiftTy : (cutoff, amt : Nat) -> STy -> STy
+shiftTy c a = mapRefsTy (\d, r, n, i => if i >= d + c then SVar r n (i + a) else SVar r n i) keepSig 0
+
+||| Remap free variables by their top-level index, keeping display data.
+remapIdxE : (Nat -> Nat) -> SElem -> SElem
+remapIdxE f = mapRefsE (\d, r, n, i => SVar r n (d + f (minus i d))) keepSig 0
+
+||| Substitute every free variable by a term over the target context
+||| (σ receives the top-level index; its result is weakened under the
+||| binders crossed).
+remapFreeE : (Nat -> SElem) -> SElem -> SElem
+remapFreeE sig = mapRefsE (\d, r, n, i => shiftE 0 d (sig (minus i d))) keepSig 0
+
+remapFreeTy : (Nat -> SElem) -> STy -> STy
+remapFreeTy sig = mapRefsTy (\d, r, n, i => shiftE 0 d (sig (minus i d))) keepSig 0
+
+||| Replace every reference to the signature name `f` by the variable
+||| whose top-level index is `base` (the uniqueness lemma states its
+||| hypotheses about the candidate g).
+replaceSigTy : (f : String) -> (gname : String) -> (base : Nat) -> STy -> STy
+replaceSigTy f gname base =
+  mapRefsTy (\_, r, n, i => SVar r n i)
+            (\d, r, x => if x == f then SVar r gname (base + d) else SSig r x) 0
+
+-- ===== Occurrence check =====
+
+mutual
+  occursE : String -> SElem -> Bool
+  occursE f (SVar _ _ _) = False
+  occursE f (SSig _ x) = x == f
+  occursE f SUnitI = False
+  occursE f SZeroN = False
+  occursE f (SSuc t) = occursE f t
+  occursE f (SLam _ t) = occursE f t
+  occursE f (SLet _ e b) = occursE f e || occursE f b
+  occursE f (SApp g e) = occursE f g || occursE f e
+  occursE f (SPair a b) = occursE f a || occursE f b
+  occursE f (SProj1 t) = occursE f t
+  occursE f (SProj2 t) = occursE f t
+  occursE f SZeroC = False
+  occursE f SOneC = False
+  occursE f SNatC = False
+  occursE f (SPiC _ a b) = occursE f a || occursE f b
+  occursE f (SSigmaC _ a b) = occursE f a || occursE f b
+  occursE f (SSumC a b) = occursE f a || occursE f b
+  occursE f (SQuotC a _ _ r) = occursE f a || occursE f r
+  occursE f (SEqC l r t) = occursE f l || occursE f r || occursTy f t
+  occursE f (SZeroElim t) = occursE f t
+  occursE f (SNatElim _ mot z _ _ s t) =
+    occursTy f mot || occursE f z || occursE f s || occursE f t
+  occursE f (SInj1 t) = occursE f t
+  occursE f (SInj2 t) = occursE f t
+  occursE f (SSumElim _ mot _ l _ r t) =
+    occursTy f mot || occursE f l || occursE f r || occursE f t
+  occursE f (SClass t) = occursE f t
+  occursE f (SQuotElim _ mot _ g q) = occursTy f mot || occursE f g || occursE f q
+  occursE f (SNuC p) = occursP f p
+  occursE f (SOut e) = occursE f e
+  occursE f (SCorec _ a g u) = occursE f a || occursE f g || occursE f u
+  occursE f (SCoind _ _ r pw _ _ _ q) = occursE f r || occursE f pw || occursE f q
+  occursE f (SSquash t) = occursTy f t
+  occursE f SStar = False
+  occursE f (SStarWit e) = occursE f e
+  occursE f (SSquashElim e _ body) = occursE f e || occursE f body
+  occursE f (SAnn e ty) = occursE f e || occursTy f ty
+  occursE f (SHole _ _ _) = False
+
+  occursTy : String -> STy -> Bool
+  occursTy f STyZero = False
+  occursTy f STyOne = False
+  occursTy f STyNat = False
+  occursTy f STyUniv = False
+  occursTy f (STySig x) = x == f
+  occursTy f (STyPi _ a b) = occursTy f a || occursTy f b
+  occursTy f (STySigma _ a b) = occursTy f a || occursTy f b
+  occursTy f (STySum a b) = occursTy f a || occursTy f b
+  occursTy f (STyQuot a _ _ r) = occursTy f a || occursE f r
+  occursTy f (STyEq l r t) = occursE f l || occursE f r || occursTy f t
+  occursTy f (STyEl e) = occursE f e
+  occursTy f STyProp = False
+  occursTy f (STyPrf e) = occursE f e
+  occursTy f (STyNu p) = occursP f p
+  occursTy f (STyHole _ _ _) = False
+
+  occursP : String -> SPoly -> Bool
+  occursP f SPHole = False
+  occursP f (SPConst a) = occursE f a
+  occursP f (SPProd p q) = occursP f p || occursP f q
+  occursP f (SPSum p q) = occursP f p || occursP f q
+  occursP f (SPSigma _ a p) = occursE f a || occursP f p
+  occursP f (SPPi _ a p) = occursE f a || occursP f p
+
+-- ===== Structural-recursion rewriting =====
+
+||| Application spine, head-first.
+unwind : SElem -> (SElem, List SElem)
+unwind (SApp g e) = let (h, as) = unwind g in (h, as ++ [e])
+unwind e = (e, [])
+
+spine : SElem -> List SElem -> SElem
+spine = foldl SApp
+
+mutual
+  ||| Replace every application spine `f a₁ … aₙ` (n ≥ |lead|) whose
+  ||| leading arguments are exactly the required variables — the
+  ||| clause's earlier column variables, then the predecessor — by the
+  ||| MARKER variable (top-level index `mk`) applied to the remaining
+  ||| (rewritten) arguments. Nothing if any occurrence of f survives
+  ||| in another shape: the recursion is not structural.
+  rwE : (f : String) -> (mk : Nat) -> (lead : List Nat) -> Nat -> SElem -> Maybe SElem
+  rwE f mk lead d e@(SApp _ _) =
+    let (h, args) = unwind e in
+    case h of
+      SSig r x =>
+        if x == f
+          then do
+            let (las, rest) = splitAt (length lead) args
+            if length las == length lead && all (\(want, got) => isReqVar (want + d) got) (zip lead las)
+              then do
+                rest' <- traverse (rwE f mk lead d) rest
+                pure (spine (SVar Nothing "ih" (mk + d)) rest')
+              else Nothing
+          else do
+            args' <- traverse (rwE f mk lead d) args
+            pure (spine (SSig r x) args')
+      _ => do
+        h' <- rwE f mk lead d h
+        args' <- traverse (rwE f mk lead d) args
+        pure (spine h' args')
+   where
+    isReqVar : Nat -> SElem -> Bool
+    isReqVar want (SVar _ _ i) = i == want
+    isReqVar _ _ = False
+  rwE f mk lead d (SVar r n i) = Just (SVar r n i)
+  rwE f mk lead d (SSig r x) = if x == f then Nothing else Just (SSig r x)
+  rwE f mk lead d SUnitI = Just SUnitI
+  rwE f mk lead d SZeroN = Just SZeroN
+  rwE f mk lead d (SSuc t) = SSuc <$> rwE f mk lead d t
+  rwE f mk lead d (SLam x t) = SLam x <$> rwE f mk lead (S d) t
+  rwE f mk lead d (SLet x e b) = [| SLet (pure x) (rwE f mk lead d e) (rwE f mk lead (S (S d)) b) |]
+  rwE f mk lead d (SPair a b) = [| SPair (rwE f mk lead d a) (rwE f mk lead d b) |]
+  rwE f mk lead d (SProj1 t) = SProj1 <$> rwE f mk lead d t
+  rwE f mk lead d (SProj2 t) = SProj2 <$> rwE f mk lead d t
+  rwE f mk lead d SZeroC = Just SZeroC
+  rwE f mk lead d SOneC = Just SOneC
+  rwE f mk lead d SNatC = Just SNatC
+  rwE f mk lead d (SPiC x a b) = [| SPiC (pure x) (rwE f mk lead d a) (rwE f mk lead (S d) b) |]
+  rwE f mk lead d (SSigmaC x a b) = [| SSigmaC (pure x) (rwE f mk lead d a) (rwE f mk lead (S d) b) |]
+  rwE f mk lead d (SSumC a b) = [| SSumC (rwE f mk lead d a) (rwE f mk lead d b) |]
+  rwE f mk lead d (SQuotC a x y r) =
+    do a' <- rwE f mk lead d a; r' <- rwE f mk lead (S (S d)) r; pure (SQuotC a' x y r')
+  rwE f mk lead d (SEqC l r t) =
+    [| SEqC (rwE f mk lead d l) (rwE f mk lead d r) (rwTy f mk lead d t) |]
+  rwE f mk lead d (SZeroElim t) = SZeroElim <$> rwE f mk lead d t
+  rwE f mk lead d (SNatElim n mot z n2 ih s t) = do
+    mot' <- rwTy f mk lead (S d) mot
+    z' <- rwE f mk lead d z
+    s' <- rwE f mk lead (S (S d)) s
+    t' <- rwE f mk lead d t
+    pure (SNatElim n mot' z' n2 ih s' t')
+  rwE f mk lead d (SInj1 t) = SInj1 <$> rwE f mk lead d t
+  rwE f mk lead d (SInj2 t) = SInj2 <$> rwE f mk lead d t
+  rwE f mk lead d (SSumElim z mot a l b r t) = do
+    mot' <- rwTy f mk lead (S d) mot
+    l' <- rwE f mk lead (S d) l
+    r' <- rwE f mk lead (S d) r
+    t' <- rwE f mk lead d t
+    pure (SSumElim z mot' a l' b r' t')
+  rwE f mk lead d (SClass t) = SClass <$> rwE f mk lead d t
+  rwE f mk lead d (SQuotElim z mot a g q) = do
+    mot' <- rwTy f mk lead (S d) mot
+    g' <- rwE f mk lead (S d) g
+    q' <- rwE f mk lead d q
+    pure (SQuotElim z mot' a g' q')
+  rwE f mk lead d (SNuC p) = SNuC <$> rwP f mk lead d p
+  rwE f mk lead d (SOut e) = SOut <$> rwE f mk lead d e
+  rwE f mk lead d (SCorec x a g u) =
+    do a' <- rwE f mk lead d a; g' <- rwE f mk lead (S d) g; u' <- rwE f mk lead d u
+       pure (SCorec x a' g' u')
+  rwE f mk lead d (SCoind nx ny r pw mx my mh q) =
+    do r' <- rwE f mk lead (S (S d)) r; pw' <- rwE f mk lead d pw
+       q' <- rwE f mk lead (S (S (S d))) q
+       pure (SCoind nx ny r' pw' mx my mh q')
+  rwE f mk lead d (SSquash t) = SSquash <$> rwTy f mk lead d t
+  rwE f mk lead d SStar = Just SStar
+  rwE f mk lead d (SStarWit e) = SStarWit <$> rwE f mk lead d e
+  rwE f mk lead d (SSquashElim e x body) =
+    do e' <- rwE f mk lead d e; body' <- rwE f mk lead (S d) body
+       pure (SSquashElim e' x body')
+  rwE f mk lead d (SAnn e ty) = [| SAnn (rwE f mk lead d e) (rwTy f mk lead d ty) |]
+  rwE f mk lead d (SHole r s x) = Just (SHole r s x)
+
+  rwTy : (f : String) -> (mk : Nat) -> (lead : List Nat) -> Nat -> STy -> Maybe STy
+  rwTy f mk lead d STyZero = Just STyZero
+  rwTy f mk lead d STyOne = Just STyOne
+  rwTy f mk lead d STyNat = Just STyNat
+  rwTy f mk lead d STyUniv = Just STyUniv
+  rwTy f mk lead d (STySig x) = if x == f then Nothing else Just (STySig x)
+  rwTy f mk lead d (STyPi x a b) = [| STyPi (pure x) (rwTy f mk lead d a) (rwTy f mk lead (S d) b) |]
+  rwTy f mk lead d (STySigma x a b) = [| STySigma (pure x) (rwTy f mk lead d a) (rwTy f mk lead (S d) b) |]
+  rwTy f mk lead d (STySum a b) = [| STySum (rwTy f mk lead d a) (rwTy f mk lead d b) |]
+  rwTy f mk lead d (STyQuot a x y r) =
+    do a' <- rwTy f mk lead d a; r' <- rwE f mk lead (S (S d)) r; pure (STyQuot a' x y r')
+  rwTy f mk lead d (STyEq l r t) =
+    [| STyEq (rwE f mk lead d l) (rwE f mk lead d r) (rwTy f mk lead d t) |]
+  rwTy f mk lead d (STyEl e) = STyEl <$> rwE f mk lead d e
+  rwTy f mk lead d STyProp = Just STyProp
+  rwTy f mk lead d (STyPrf e) = STyPrf <$> rwE f mk lead d e
+  rwTy f mk lead d (STyNu p) = STyNu <$> rwP f mk lead d p
+  rwTy f mk lead d (STyHole r s x) = Just (STyHole r s x)
+
+  rwP : (f : String) -> (mk : Nat) -> (lead : List Nat) -> Nat -> SPoly -> Maybe SPoly
+  rwP f mk lead d SPHole = Just SPHole
+  rwP f mk lead d (SPConst a) = SPConst <$> rwE f mk lead d a
+  rwP f mk lead d (SPProd p q) = [| SPProd (rwP f mk lead d p) (rwP f mk lead d q) |]
+  rwP f mk lead d (SPSum p q) = [| SPSum (rwP f mk lead d p) (rwP f mk lead d q) |]
+  rwP f mk lead d (SPSigma x a p) = [| SPSigma (pure x) (rwE f mk lead d a) (rwP f mk lead (S d) p) |]
+  rwP f mk lead d (SPPi x a p) = [| SPPi (pure x) (rwE f mk lead d a) (rwP f mk lead (S d) p) |]
+
+-- ===== Columns and patterns =====
+
+nth : Nat -> List a -> Maybe a
+nth _ [] = Nothing
+nth Z (x :: _) = Just x
+nth (S n) (_ :: xs) = nth n xs
+
+||| Peel exactly k leading Π's off the item's SURFACE type: the
+||| COLUMNS the clauses pattern, plus the rest (which may itself be a
+||| Π-type — the generated equations then sit at a function type).
+peelPis : Nat -> STy -> Maybe (List (String, STy), STy)
+peelPis Z ty = Just ([], ty)
+peelPis (S n) (STyPi x a b) = do
+  (cols, rest) <- peelPis n b
+  pure ((x, a) :: cols, rest)
+peelPis (S n) _ = Nothing
+
+||| Syntactic ℕ-recognition (the spec reads whnf(Aⱼ); the syntactic
+||| approximation only narrows the FRAGMENT — unrecognized split
+||| types degrade, which is always sound).
+tyNat : STy -> Bool
+tyNat STyNat = True
+tyNat (STyEl SNatC) = True
+tyNat _ = False
+
+tySumParts : STy -> Maybe (STy, STy)
+tySumParts (STySum a b) = Just (a, b)
+tySumParts (STyEl (SSumC a b)) = Just (STyEl a, STyEl b)
+tySumParts _ = Nothing
+
+||| A pattern with its variable's telescope SLOT resolved (0-based,
+||| outermost first) and whether this occurrence BINDS the slot (a
+||| repeated name reuses an earlier slot — nonlinear LHS).
+data PatSk : Type where
+  KVar : SName -> (slot : Nat) -> (binds : Bool) -> PatSk
+  KZero : PatSk
+  KSuc : PatSk -> PatSk
+  KInj1 : PatSk -> PatSk
+  KInj2 : PatSk -> PatSk
+
+indexOf : Eq a => a -> List a -> Maybe Nat
+indexOf x [] = Nothing
+indexOf x (y :: ys) = if x == y then Just 0 else map S (indexOf x ys)
+
+||| Slot assignment, mirroring the parser's patVarsOf exactly: one
+||| slot per variable in order of first appearance, wildcards always
+||| fresh.
+assignSlots : List SPat -> (List PatSk, Nat)
+assignSlots pats =
+  let (sks, slots) = go [] pats in (sks, length slots)
+ where
+  goP : List String -> SPat -> (PatSk, List String)
+  goP seen (SPVar x) =
+    case (fst x /= wildcard, indexOf (fst x) seen) of
+      (True, Just i) => (KVar x i False, seen)
+      _ => (KVar x (length seen) True, seen ++ [fst x])
+  goP seen SPZero = (KZero, seen)
+  goP seen (SPSuc p) = let (sk, seen') = goP seen p in (KSuc sk, seen')
+  goP seen (SPInj1 p) = let (sk, seen') = goP seen p in (KInj1 sk, seen')
+  goP seen (SPInj2 p) = let (sk, seen') = goP seen p in (KInj2 sk, seen')
+  go : List String -> List SPat -> (List PatSk, List String)
+  go seen [] = ([], seen)
+  go seen (p :: ps) =
+    let (sk, seen') = goP seen p
+        (sks, seen'') = go seen' ps
+    in (sk :: sks, seen'')
+
+||| The pattern as a surface element over a context of `n` binders
+||| whose innermost `slots` entries are the telescope.
+patTerm : (ctxSize : Nat) -> PatSk -> SElem
+patTerm n (KVar x s _) = SVar (snd x) (fst x) (minus n (S s))
+patTerm n KZero = SZeroN
+patTerm n (KSuc p) = SSuc (patTerm n p)
+patTerm n (KInj1 p) = SInj1 (patTerm n p)
+patTerm n (KInj2 p) = SInj2 (patTerm n p)
+
+||| The telescope entries a pattern binds, given its (transported)
+||| column type. Fails when the pattern's constructors do not match
+||| the column type's syntactic shape — a STRUCTURAL error (the
+||| clause's statement would be untypable).
+typePat : STy -> PatSk -> Either String (List (SName, STy))
+typePat a (KVar x _ True) = Right [(x, a)]
+typePat a (KVar x _ False) = Right []
+typePat a KZero =
+  if tyNat a then Right [] else Left "pattern Z at a column whose type is not ℕ"
+typePat a (KSuc p) =
+  if tyNat a then typePat STyNat p
+             else Left "pattern S … at a column whose type is not ℕ"
+typePat a (KInj1 p) =
+  case tySumParts a of
+    Just (l, _) => typePat l p
+    Nothing => Left "pattern inj₁ … at a column whose type is not a ⊎"
+typePat a (KInj2 p) =
+  case tySumParts a of
+    Just (_, r) => typePat r p
+    Nothing => Left "pattern inj₂ … at a column whose type is not a ⊎"
+
+||| Per-clause data: the pattern telescope (outermost first), the
+||| resolved pattern skeletons, and the LHS argument spine over the
+||| full telescope.
+record ClauseData where
+  constructor MkClauseData
+  csks : List PatSk
+  ctele : List (SName, STy)
+  cargs : List SElem
+
+buildClauseData : List (String, STy) -> SClause -> Either String ClauseData
+buildClauseData cols clause = do
+  let (sks, nslots) = assignSlots clause.cpats
+  tele <- go 0 [] (map snd cols) sks
+  let args = map (patTerm nslots) sks
+  if length tele == length clause.cvars
+    then Right (MkClauseData sks tele args)
+    else Left "internal: pattern telescope disagrees with the parser's"
+ where
+  -- position by position: transport the column type to the telescope
+  -- context (substituting the EARLIER positions' pattern terms — kept
+  -- in `past`, most recent first — for the earlier column variables),
+  -- then read the position's binder off the pattern
+  go : (bound : Nat) -> (past : List PatSk) -> List STy -> List PatSk ->
+       Either String (List (SName, STy))
+  go bound past [] [] = Right []
+  go bound past (a :: as) (sk :: sks) = do
+    let a' = remapFreeTy (\d => maybe SUnitI (patTerm bound) (nth d past)) a
+    binds <- typePat a' sk
+    rest <- go (bound + length binds) (sk :: past) as sks
+    pure (binds ++ rest)
+  go _ _ _ _ = Left "internal: column/pattern arity mismatch"
+
+-- ===== The structural fragment =====
+
+||| The clause shapes the v1 splitter compiles (docs/NovaElaboration.txt,
+||| "THE STRUCTURAL FRAGMENT"): one split column at ℕ or ⊎, depth-1
+||| patterns, everything else variables, linear LHSs. The recursion
+||| condition is checked separately (it gates ρ, not the uniqueness
+||| synthesis).
+data Shape : Type where
+  ||| single all-variable clause
+  ShNone : SClause -> Shape
+  ||| split at 1-based column j: the Z-clause, the S-clause and its
+  ||| predecessor variable
+  ShNat : (j : Nat) -> (zc, sc : SClause) -> (mvar : SName) -> Shape
+  ||| split at 1-based column j: the payload types and the two clauses
+  ||| with their payload variables
+  ShSum : (j : Nat) -> (lc : SClause) -> (avar : SName) ->
+          (rc : SClause) -> (bvar : SName) -> Shape
+
+isVarPat : SPat -> Bool
+isVarPat (SPVar _) = True
+isVarPat _ = False
+
+||| Linear: no non-wildcard variable occurs twice in one clause's LHS.
+linearClause : SClause -> Bool
+linearClause c =
+  let occs = concatMap patNames c.cpats in
+  length (filter (/= wildcard) occs) == length (nub (filter (/= wildcard) occs))
+ where
+  patNames : SPat -> List String
+  patNames (SPVar x) = [fst x]
+  patNames SPZero = []
+  patNames (SPSuc p) = patNames p
+  patNames (SPInj1 p) = patNames p
+  patNames (SPInj2 p) = patNames p
+
+analyzeShape : List (String, STy) -> List SClause -> Maybe Shape
+analyzeShape cols clauses =
+  if not (all linearClause clauses) then Nothing else
+  let pmat = map (.cpats) clauses
+      cands = findAll 0 (transpose pmat)
+  in case (cands, clauses) of
+       ([], [c]) => Just (ShNone c)
+       ([i], [c1, c2]) =>
+         case nth i (map snd cols) of
+           Nothing => Nothing
+           Just a =>
+             if tyNat a
+               then natShape i c1 c2 <|> natShape i c2 c1
+               else case tySumParts a of
+                      Just _ => sumShape i c1 c2 <|> sumShape i c2 c1
+                      Nothing => Nothing
+       _ => Nothing
+ where
+  findAll : Nat -> List (List SPat) -> List Nat
+  findAll i [] = []
+  findAll i (ps :: rest) =
+    (if any (not . isVarPat) ps then [i] else []) ++ findAll (S i) rest
+  natShape : Nat -> SClause -> SClause -> Maybe Shape
+  natShape i zc sc =
+    case (nth i zc.cpats, nth i sc.cpats) of
+      (Just SPZero, Just (SPSuc (SPVar m))) => Just (ShNat (S i) zc sc m)
+      _ => Nothing
+  sumShape : Nat -> SClause -> SClause -> Maybe Shape
+  sumShape i lc rc =
+    case (nth i lc.cpats, nth i rc.cpats) of
+      (Just (SPInj1 (SPVar a)), Just (SPInj2 (SPVar b))) =>
+        Just (ShSum (S i) lc a rc b)
+      _ => Nothing
+
+-- ===== Synthesis =====
+
+wrapSLams : List SName -> SElem -> SElem
+wrapSLams xs e = foldr SLam e xs
+
+wrapSPis : List (SName, STy) -> STy -> STy
+wrapSPis xs t = foldr (\(x, a), r => STyPi (fst x) a r) t xs
+
+||| The Π-closure of the trailing columns over the split variable:
+||| the eliminator motive's chain. Piece d of the chain (0-based)
+||| shifts +1 for indices ≥ d+1 — the λ-bound split column interposes
+||| between the motive binder and the leading columns.
+motChain : (trailing : List (String, STy)) -> STy -> STy
+motChain trailing result = go 0 trailing
+ where
+  go : Nat -> List (String, STy) -> STy
+  go d [] = result
+  go d ((x, a) :: rest) = STyPi x (shiftTy (S d) 1 a) (go (S d) rest)
+
+||| λ-binders for the leading j columns (display names from the type's
+||| own binders).
+leadLams : (cols : List (String, STy)) -> (j : Nat) -> SElem -> SElem
+leadLams cols j e = wrapSLams (map (\(x, _) => (x, Nothing)) (take j cols)) e
+
+||| The display binder for a column: its Π-binder name from the
+||| item's own type.
+colBinder : List (String, STy) -> (i : Nat) -> SName
+colBinder cols i =
+  case nth i cols of
+    Just (x, _) => (x, Nothing)
+    Nothing => ("x", Nothing)
+
+||| The witness ρ for an ℕ split at 1-based column j of k: eliminate
+||| the split variable at the Π-motive over the trailing columns.
+||| Nothing when the recursion is not structural.
+rhoNat : (fname : String) -> (cols : List (String, STy)) -> (b : STy) ->
+         (j, k : Nat) -> (zc, sc : SClause) -> (mvar : SName) -> Maybe SElem
+rhoNat fname cols b j k zc sc mvar = do
+  let kj = minus k j
+  -- the Z-clause must not mention f at all
+  let False = occursE fname zc.crhs
+    | True => Nothing
+  -- required leading arguments of a recursive call: the clause's own
+  -- column variables (top-level indices k−1 … k−j+1), then the
+  -- predecessor (k−j)
+  let lead = map (\i => minus k i) [1 .. j]
+  sBody <- rwE fname k lead 0 sc.crhs
+  let zBody = wrapSLams (drop (minus j 1) zc.cvars) (shiftE kj 1 zc.crhs)
+  let sBody' = wrapSLams (drop j sc.cvars) (remapIdxE (msMap kj) sBody)
+  let mot = motChain (drop j cols) (shiftTy (S kj) 1 b)
+  let xname = colBinder cols (minus j 1)
+  pure (leadLams cols j
+         (SNatElim xname mot zBody mvar ("ih", Nothing) sBody' (SVar Nothing (fst xname) 0)))
+ where
+  -- clause context [x₁…x_{j−1}, m, trailing] (size k, marker at k) to
+  -- case context [x₁…x_j (λ), m, ih, trailing]
+  msMap : Nat -> Nat -> Nat
+  msMap kj e =
+    if e < kj then e
+    else if e == kj then S kj
+    else if e == k then kj
+    else e + 2
+
+||| The witness ρ for a ⊎ split: no recursion (⊎-elim has no
+||| induction hypothesis), so neither clause may mention f.
+rhoSum : (fname : String) -> (cols : List (String, STy)) -> (b : STy) ->
+         (j, k : Nat) -> (lc : SClause) -> (avar : SName) ->
+         (rc : SClause) -> (bvar : SName) -> Maybe SElem
+rhoSum fname cols b j k lc avar rc bvar = do
+  let False = occursE fname lc.crhs
+    | True => Nothing
+  let False = occursE fname rc.crhs
+    | True => Nothing
+  let kj = minus k j
+  -- clause context [x₁…x_{j−1}, payload, trailing] to case context
+  -- [x₁…x_j (λ), payload, trailing]: the λ-bound split column
+  -- interposes above the payload
+  let lBody = wrapSLams (drop j lc.cvars) (shiftE (S kj) 1 lc.crhs)
+  let rBody = wrapSLams (drop j rc.cvars) (shiftE (S kj) 1 rc.crhs)
+  let mot = motChain (drop j cols) (shiftTy (S kj) 1 b)
+  let xname = colBinder cols (minus j 1)
+  pure (leadLams cols j
+         (SSumElim xname mot avar lBody bvar rBody (SVar Nothing (fst xname) 0)))
+
+||| The no-split witness: λ-abstraction alone.
+rhoNone : (fname : String) -> SClause -> Maybe SElem
+rhoNone fname c = do
+  let False = occursE fname c.crhs
+    | True => Nothing
+  pure (wrapSLams c.cvars c.crhs)
+
+||| The pointwise uniqueness STATEMENT:
+|||   (g : T) → (h₁ : clause₁[g/f]) → … → (x₁:A₁) → … → g x̄ ≡ f x̄ ∈ B
+||| The h-binders reuse the clause lemmas' names (display only); the
+||| trailing binders are the columns, so the equation's sides
+||| determine them — the h's are SIDE CONDITIONS in E's documented
+||| sense.
+etaType : (fname : String) -> (ty : STy) -> (cols : List (String, STy)) ->
+          (b : STy) -> (lemNames : List String) -> (lemTys : List STy) -> STy
+etaType fname ty cols b lemNames lemTys =
+  let k = length cols
+      m = length lemTys
+      hyps = the (List (SName, STy))
+               (zipWith (\i, nt => ((fst nt, Nothing), replaceSigTy fname "g" i (snd nt)))
+                        [0 .. minus m 1] (zip lemNames lemTys))
+      colBinds = the (List (SName, STy)) (map (\(x, a) => ((x, Nothing), a)) cols)
+      args = map (\i => SVar Nothing (colName i) (minus k i)) [1 .. k]
+      concl = STyEq (spine (SVar Nothing "g" (k + m)) args)
+                    (spine (SSig Nothing fname) args) b
+  in STyPi "g" ty (wrapSPis hyps (wrapSPis colBinds concl))
+ where
+  colName : Nat -> String
+  colName i = maybe "_" fst (nth (minus i 1) cols)
+
+||| The uniqueness PROOF for a fragment-shaped item: the eliminator at
+||| the pointwise equality motive, both cases ⋆ — discharged from the
+||| g-clause hypotheses, the induction hypothesis, and the clause
+||| lemmas (docs/NovaKernel.txt caveat A5: no η finals exist or are
+||| needed). For the no-split shape (and as the unshaped fallback) the
+||| body is the bare λ…. ⋆.
+etaBodyStar : (m, k : Nat) -> (lemNames : List String) ->
+              (cols : List (String, STy)) -> SElem
+etaBodyStar m k lemNames cols =
+  SLam ("g", Nothing)
+    (wrapSLams (map (\n => (n, Nothing)) lemNames)
+      (wrapSLams (map (\(x, _) => (x, Nothing)) cols) SStar))
+
+etaBodyElim : (fname : String) -> (cols : List (String, STy)) -> (b : STy) ->
+              (j, k, m : Nat) -> (lemNames : List String) ->
+              (isNat : Bool) -> (v1, v2 : SName) -> SElem
+etaBodyElim fname cols b j k m lemNames isNat v1 v2 =
+  let kj = minus k j
+      trailing = drop j cols
+      -- context at the motive's equation: [g, h's, x₁…x_j, x, trailing]
+      args = map (\i => SVar Nothing (colName i)
+                    (if i < j then (minus k i) + 1
+                     else if i == j then kj
+                     else minus k i)) [1 .. k]
+      concl = STyEq (spine (SVar Nothing "g" (m + k + 1)) args)
+                    (spine (SSig Nothing fname) args)
+                    (shiftTy (S kj) 1 b)
+      mot = motChain trailing concl
+      trailLams = wrapSLams (map (\(x, _) => (x, Nothing)) trailing) SStar
+      xname = colBinder cols (minus j 1)
+      scrut = SVar Nothing (fst xname) 0
+      elim = if isNat
+               then SNatElim xname mot trailLams v1 ("ih", Nothing) trailLams scrut
+               else SSumElim xname mot v1 trailLams v2 trailLams scrut
+  in SLam ("g", Nothing)
+       (wrapSLams (map (\n => (n, Nothing)) lemNames)
+         (leadLams cols j elim))
+ where
+  colName : Nat -> String
+  colName i = maybe "_" fst (nth (minus i 1) cols)
+
+-- ===== Naming =====
+
+defaultTag : SClause -> String
+defaultTag c = go c.cpats
+ where
+  tag : SPat -> Maybe String
+  tag (SPVar _) = Nothing
+  tag SPZero = Just "Z"
+  tag (SPSuc _) = Just "S"
+  tag (SPInj1 _) = Just "Inl"
+  tag (SPInj2 _) = Just "Inr"
+  go : List SPat -> String
+  go [] = "Eq"
+  go (p :: ps) = fromMaybe (go ps) (tag p)
+
+||| Every Σ-name a clausal item mints (the definition, the clause
+||| lemmas, the uniqueness lemma) — a pure function of the source, per
+||| the reproducibility invariant. Used by the expansion and by the
+||| LSP's symbol listing.
+export
+clausalNames : String -> Maybe String -> List SClause -> List String
+clausalNames fname etaName cls =
+  fname :: map (\c => fromMaybe (fname ++ defaultTag c) c.cname) cls
+        ++ [fromMaybe (fname ++ "Eta") etaName]
+
+-- ===== The expansion =====
+
+public export
+record Expansion where
+  constructor MkExpansion
+  items : List SItem
+  echo : String
+
+||| Expand a clausal def into its batch (docs/NovaElaboration.txt,
+||| "Defining equations"). Left = STRUCTURAL error (malformed clauses:
+||| arity mismatch, unpeelable columns, untypable patterns, missing
+||| name overrides on an operator-named item). Everything else
+||| degrades through the tiers: full synthesis / witness-supplied /
+||| declarations — one semantics, three labor divisions.
+export
+expandClausal : (nrng : Maybe Range) -> (fname : String) -> STy ->
+                (etaName : Maybe String) -> (witness : Maybe SElem) ->
+                List SClause -> Either String Expansion
+expandClausal nrng fname ty etaName witness clauses = do
+  -- arity and columns
+  k <- case map (length . cpats) clauses of
+         [] => Left "at least one clause is required"
+         (n :: ns) =>
+           if not (all (== n) ns)
+             then Left "clauses disagree on the number of pattern positions"
+             else if n == 0
+               then Left "a clause must spell at least one pattern position"
+               else Right n
+  (cols, b) <- maybe (Left ("the clauses spell \{show k} pattern positions, "
+                            ++ "but the item's type does not show \{show k} leading Π-columns"))
+                     Right (peelPis k ty)
+  -- names: deterministic defaults; an operator-named item has no
+  -- identifier to prefix, so every override is mandatory
+  lemNames <-
+    if isOpName fname
+      then traverse (\c => maybe (Left "an operator-named item requires a [name] override on every clause")
+                                 Right c.cname) clauses
+      else Right (map (\c => fromMaybe (fname ++ defaultTag c) c.cname) clauses)
+  etaN <-
+    if isOpName fname
+      then maybe (Left "an operator-named item requires a [name] override (after the type) for the uniqueness lemma")
+                 Right etaName
+      else Right (fromMaybe (fname ++ "Eta") etaName)
+  -- per-clause telescopes and lemma statements
+  cds <- traverse (buildClauseData cols) clauses
+  let lemTys = zipWith (mkLemTy cols b k) clauses cds
+  let lemBodies = map (\cd => wrapSLams (map fst cd.ctele) SStar) cds
+  let m = length clauses
+  let eTy = etaType fname ty cols b lemNames lemTys
+  let shape = analyzeShape cols clauses
+  let eBodySynth = map (shapedEtaBody cols b k m lemNames) shape
+  let eBodyStar = etaBodyStar m k lemNames cols
+  let names = fname :: lemNames ++ [etaN]
+  case witness of
+    Just w =>
+      -- WITNESS TIER: existence is the user's; the clause lemmas pay
+      -- with ⋆ (undischarged ⋆'s are ordinary obligations), and the
+      -- uniqueness proof is still synthesized whenever the clauses
+      -- are fragment-shaped — it rewrites by the clause lemmas, never
+      -- by unfolding the witness
+      Right (MkExpansion
+               (SDef fname ty w
+                  :: zipWith3 SDef lemNames lemTys lemBodies
+                  ++ [SDef etaN eTy (fromMaybe eBodyStar eBodySynth)])
+               "defined \{fname} by clauses via witness (\{joinBy ", " names})")
+    Nothing =>
+      case (shape, shape >>= shapedRho cols b k) of
+        (Just _, Just rho) =>
+          -- THE FRAGMENT: everything synthesized
+          Right (MkExpansion
+                   (SDef fname ty rho
+                      :: zipWith3 SDef lemNames lemTys lemBodies
+                      ++ [SDef etaN eTy (fromMaybe eBodyStar eBodySynth)])
+                   "defined \{fname} by clauses (\{joinBy ", " names})")
+        _ =>
+          -- DECLARATION TIER: the whole batch demotes to named rigid
+          -- holes; the equation lemmas register in the lemma store as
+          -- declared equations (the abstract-interface idiom), so the
+          -- file downstream elaborates against the interface
+          Right (MkExpansion
+                   (SDeclDef nrng fname ty
+                      :: zipWith (SDeclDef Nothing) lemNames lemTys
+                      ++ [SDeclDef Nothing etaN eTy])
+                   ("declared \{fname} and its equations (\{joinBy ", " names})"
+                    ++ " — clauses outside the structural fragment"))
+ where
+  ||| Π(Γᵢ). f p̄ᵢ ≡ tᵢ ∈ B[p̄ᵢ] — the clause, Π-closed over its pattern
+  ||| telescope; recursive occurrences in tᵢ stay references to f.
+  mkLemTy : List (String, STy) -> STy -> Nat -> SClause -> ClauseData -> STy
+  mkLemTy cols b k clause cd =
+    let bigL = length cd.ctele
+        lhs = spine (SSig Nothing fname) cd.cargs
+        bC = remapFreeTy (\d => maybe SUnitI (patTerm bigL) (nth d (reverse cd.csks))) b
+    in wrapSPis cd.ctele (STyEq lhs clause.crhs bC)
+
+  shapedRho : List (String, STy) -> STy -> Nat -> Shape -> Maybe SElem
+  shapedRho cols b k (ShNone c) = rhoNone fname c
+  shapedRho cols b k (ShNat j zc sc mvar) = rhoNat fname cols b j k zc sc mvar
+  shapedRho cols b k (ShSum j lc avar rc bvar) = rhoSum fname cols b j k lc avar rc bvar
+
+  shapedEtaBody : List (String, STy) -> STy -> Nat -> Nat -> List String -> Shape -> SElem
+  shapedEtaBody cols b k m lemNames (ShNone _) = etaBodyStar m k lemNames cols
+  shapedEtaBody cols b k m lemNames (ShNat j _ sc mvar) =
+    etaBodyElim fname cols b j k m lemNames True mvar ("ih", Nothing)
+  shapedEtaBody cols b k m lemNames (ShSum j _ avar _ bvar) =
+    etaBodyElim fname cols b j k m lemNames False avar bvar

--- a/src/idris/Nova/Elaboration/Parser.idr
+++ b/src/idris/Nova/Elaboration/Parser.idr
@@ -624,13 +624,93 @@ parseSData tbl = do
     rest <- optional (do sp; kwc ';'; sp; go penv (entries :< d.dqname))
     pure (d :: fromMaybe [] rest)
 
+-- ===== Defining equations (the clausal def item) =====
+--
+-- Clause LHSs are pattern spellings headed by the item's own name;
+-- the marker `|` is RESERVED for this role (withdrawn from the
+-- operator alphabet — see Nova.Elaboration.Surface.opChar), and the
+-- clause separator is ≔, as at def, so `=` stays an ordinary
+-- operator token.
+
+mutual
+  ||| pat ::= x | Z | S pat | inj₁ pat | inj₂ pat | (pat) — any depth
+  ||| (the FRAGMENT demands depth 1, the grammar does not); constructor
+  ||| arguments sit at atom level, like application arguments.
+  parsePat : Rule SPat
+  parsePat =
+        (do kw "S"; space; p <- parsePatAtom; pure (SPSuc p))
+    <|> (do kw "inj₁"; space; p <- parsePatAtom; pure (SPInj1 p))
+    <|> (do kw "inj₂"; space; p <- parsePatAtom; pure (SPInj2 p))
+    <|> parsePatAtom
+
+  parsePatAtom : Rule SPat
+  parsePatAtom =
+        (kw "Z" $> SPZero)
+    <|> (do kwc '('; sp; p <- parsePat; sp; kwc ')'; pure p)
+    <|> (do x <- parseNameR; pure (SPVar x))
+
+||| The binder telescope a clause's patterns spell: one slot per
+||| variable in order of first appearance; a wildcard is always a
+||| fresh slot, a repeated name reuses its slot (nonlinear LHS —
+||| expressible here, rejected by the structural fragment).
+patVarsOf : List SPat -> List SName
+patVarsOf = foldl goP []
+ where
+  goP : List SName -> SPat -> List SName
+  goP acc (SPVar x) =
+    if fst x /= wildcard && elem (fst x) (map fst acc)
+      then acc
+      else acc ++ [x]
+  goP acc SPZero = acc
+  goP acc (SPSuc p) = goP acc p
+  goP acc (SPInj1 p) = goP acc p
+  goP acc (SPInj2 p) = goP acc p
+
+||| lhs ::= n pat* | pat op pat — the head must be the item's own name
+||| (parsed as an ordinary application or infix spelling and REREAD as
+||| patterns; the mention form (op) works as a prefix head).
+parseClauseLhs : String -> Rule (List SPat)
+parseClauseLhs iname =
+      (do h <- parseHead
+          guard "the clause head must be the item's name" (h == iname)
+          many (do sp; parsePatAtom))
+  <|> (do p1 <- parsePat; sp
+          op <- parseOpName
+          guard "the clause head must be the item's name" (op == iname)
+          sp
+          p2 <- parsePat
+          pure [p1, p2])
+ where
+  parseHead : Rule String
+  parseHead =
+        parseName
+    <|> parseOpName
+    <|> (do kwc '('; sp; op <- parseOpRef; sp; kwc ')'; pure op)
+
+||| clause ::= | lhs ≔ t ([n])? — the RHS is parsed in the LHS's
+||| binder telescope; the optional [n] names the clause's equation
+||| lemma.
+parseSClause : FixTable -> String -> Rule SClause
+parseSClause tbl iname = do
+  kwc '|'; sp
+  commit
+  pats <- parseClauseLhs iname
+  sp; kw "≔"; sp
+  let vars = patVarsOf pats
+  rhs <- parseSElem tbl ([<] <>< map fst vars)
+  mn <- optional (do sp; kwc '['; sp; n <- parseName; sp; kwc ']'; pure n)
+  pure (MkSClause pats vars rhs mn)
+
 -- COMMITS: after an item's leading keyword the parse can be nothing
 -- else, so commit — a failure deep inside the item then propagates
 -- with its REAL position instead of backtracking to the item
 -- boundary, where the file loop would end and report a useless
 -- "Expected end of input" at the next `def`. The commit inside the
 -- optional ≔-body keeps `def x : T ≔ <garbage>` a hard error at the
--- garbage rather than mis-reading the item as a declaration.
+-- garbage rather than mis-reading the item as a declaration. The
+-- commit after a clause's `|` likewise keeps a malformed clause a
+-- hard error while letting the clause loop end cleanly at the next
+-- item.
 export
 parseSItem : FixTable -> Rule SItem
 parseSItem tbl =
@@ -638,11 +718,15 @@ parseSItem tbl =
           (r, x) <- bounds (parseName <|> parseOpName); sp
           kwc ':'; sp
           ty <- parseSTy tbl [<]; sp
+          metaEta <- optional (do kwc '['; sp; n <- parseName; sp; kwc ']'; sp; pure n)
           mbody <- optional (do kw "≔"; sp; commit; parseSElem tbl [<])
-          pure (case mbody of
-                  Just body => SDef x ty body
-                  -- a def without a definiens: a DECLARATION
-                  Nothing => SDeclDef r x ty))
+          cls <- many (do sp; parseSClause tbl x)
+          case (metaEta, mbody, cls) of
+            (Nothing, Just body, []) => pure (SDef x ty body)
+            -- a def without a definiens: a DECLARATION
+            (Nothing, Nothing, []) => pure (SDeclDef r x ty)
+            (_, _, (c :: cs)) => pure (SClausalDef r x ty metaEta mbody (c :: cs))
+            (Just _, _, []) => fail "clauses expected after a uniqueness-name override")
   <|> (do kw "type"; space; commit
           x <- parseName; sp
           kw "≔"; sp

--- a/src/idris/Nova/Elaboration/Surface.idr
+++ b/src/idris/Nova/Elaboration/Surface.idr
@@ -185,11 +185,12 @@ FixTable : Type
 FixTable = List (String, Assoc, Nat)
 
 ||| The operator alphabet. Excludes the reserved theory tokens
-||| (→ ⨯ ≡ ∈ ≔ / . , : parens) and comment dashes are eaten by the
-||| lexer, so no operator may contain "--".
+||| (→ ⨯ ≡ ∈ ≔ / . , : parens) — and `|`, the clause marker of the
+||| clausal def item — and comment dashes are eaten by the lexer, so
+||| no operator may contain "--".
 public export
 opChar : Char -> Bool
-opChar c = c `elem` unpack "+-*<>=&|!?%^~@#⊕⊗⊙⊞⊟∙∘·≤≥∸⧺⊥⊤∧∨⊃¬↔"
+opChar c = c `elem` unpack "+-*<>=&!?%^~@#⊕⊗⊙⊞⊟∙∘·≤≥∸⧺⊥⊤∧∨⊃¬↔"
 
 ||| Is the (possibly qualified) name operator-shaped? Decided by its
 ||| final segment.
@@ -242,6 +243,35 @@ record SQDecl where
   dqbinders : List (String, Either STy SQTm)
   dqres : SQRes
 
+-- ===== Defining equations (the clausal def item) =====
+
+||| A clause LHS pattern (docs/NovaElaboration.txt, "Defining
+||| equations"): constructor spellings and variables, any depth — the
+||| structural FRAGMENT demands depth 1, the grammar does not.
+public export
+data SPat : Type where
+  SPVar : SName -> SPat
+  SPZero : SPat
+  SPSuc : SPat -> SPat
+  SPInj1 : SPat -> SPat
+  SPInj2 : SPat -> SPat
+
+||| One defining equation: `| lhs ≔ rhs [name]?`. The LHS patterns
+||| cover the leading columns of the item's type; `cvars` is the
+||| binder telescope the patterns spell — one slot per variable in
+||| order of first appearance (a wildcard is always a fresh slot, a
+||| repeated name reuses its slot — nonlinear LHSs are expressible,
+||| the fragment rejects them). The RHS is parsed in exactly that
+||| environment.
+public export
+record SClause where
+  constructor MkSClause
+  cpats : List SPat
+  cvars : List SName
+  crhs : SElem
+  ||| the [name] override for this clause's equation lemma
+  cname : Maybe String
+
 public export
 data SItem : Type where
   ||| def x : T ≔ t — always in the empty context
@@ -258,6 +288,15 @@ data SItem : Type where
   ||| Π-abstracted over the parameters (docs/NovaElaboration.txt,
   ||| QIIT section)
   SData : List (String, STy) -> List SQDecl -> SItem
+  ||| def x : T [eta]? (≔ t)? clause+ — a def with DEFINING EQUATIONS
+  ||| (docs/NovaElaboration.txt, "Defining equations"): an ITEM MACRO
+  ||| expanding into the definition proper (a synthesized eliminator
+  ||| body, the user's witness t, or a declaration), one Π-closed
+  ||| equation lemma per clause, and the pointwise uniqueness lemma
+  ||| (named by the [eta] override)
+  SClausalDef : (nrng : Maybe Range) -> String -> STy ->
+                (etaName : Maybe String) -> (witness : Maybe SElem) ->
+                List SClause -> SItem
 
 export
 itemName : SItem -> String
@@ -267,6 +306,7 @@ itemName (STypeDef n _) = n
 itemName (SData _ ds) = case ds of
   (d :: _) => d.dqname
   [] => "data"
+itemName (SClausalDef _ n _ _ _ _) = n
 
 -- ===== Show instances (parser golden tests) =====
 
@@ -349,6 +389,20 @@ Show SImport where
   show (MkSImport m os) = "import \{m} (\{joinBy ", " os})"
 
 export covering
+Show SPat where
+  show (SPVar x) = fst x
+  show SPZero = "Z"
+  show (SPSuc p) = "S (\{show p})"
+  show (SPInj1 p) = "Inj1 (\{show p})"
+  show (SPInj2 p) = "Inj2 (\{show p})"
+
+export covering
+Show SClause where
+  show (MkSClause ps _ rhs mn) =
+    "| " ++ joinBy " " (map show ps) ++ " := " ++ show rhs
+      ++ maybe "" (\n => " [\{n}]") mn
+
+export covering
 Show SQTm where
   show (SQVar n i) = "\{n}@⬡\{show i}"
   show (SQAppE f e) = "AppE (\{show f}) (\{show e})"
@@ -377,3 +431,8 @@ Show SItem where
   show (SData ps ds) =
     "data " ++ concatMap (\p => case p of (x, t) => "[\{x} : \{show t}] ") ps
       ++ "(" ++ joinBy " ; " (map show ds) ++ ")"
+  show (SClausalDef _ x ty eta w cls) =
+    "def \{x} : \{show ty}"
+      ++ maybe "" (\n => " [\{n}]") eta
+      ++ maybe "" (\t => " := \{show t}") w
+      ++ concatMap (\c => " \{show c}") cls

--- a/src/idris/Nova/LSP/Definitions.idr
+++ b/src/idris/Nova/LSP/Definitions.idr
@@ -20,6 +20,7 @@ import Language.LSP.Message.Location
 import Nova.Kernel.Parser
 import Nova.Elaboration
 import Nova.Elaboration.Surface
+import Nova.Elaboration.Clauses
 import Nova.Elaboration.Loader
 
 import Nova.LSP.Encoding
@@ -54,6 +55,7 @@ itemNames (SDef x _ _) = [x]
 itemNames (SDeclDef _ x _) = [x]
 itemNames (STypeDef x _) = [x]
 itemNames (SData _ decls) = map dqname decls
+itemNames (SClausalDef _ x _ eta _ cls) = clausalNames x eta cls
 
 ||| Σ's own qualification: bare in the root file, module-prefixed
 ||| otherwise (`Nova.Elaboration.emitCoreDef`'s `q`).
@@ -163,3 +165,4 @@ documentSymbols lns = concatMap toSymbols
       SDeclDef _ x _ => [mkSymbol lns x Function r]
       STypeDef x _  => [mkSymbol lns x Class r]
       SData _ decls => map (\d => mkSymbol lns d.dqname (declSymbolKind d.dqres) r) decls
+      SClausalDef _ x _ eta _ cls => map (\n => mkSymbol lns n Function r) (clausalNames x eta cls)

--- a/src/nova/definingEq.nova
+++ b/src/nova/definingEq.nova
@@ -1,0 +1,57 @@
+-- Defining equations (docs/NovaElaboration.txt, "Defining equations"):
+-- a def with clauses is an ITEM MACRO expanding into the definition
+-- proper, one Π-closed equation lemma per clause, and the pointwise
+-- uniqueness lemma — the three pieces of the contractibility
+-- contract. Everything in this file is accepted with zero
+-- obligations.
+
+-- ℕ split with structural recursion: the witness is a synthesized
+-- ℕ-elim, the clause lemmas (plusZ, plusS) hold by computation, and
+-- plusEta is the A5-route uniqueness proof — an ordinary eliminator
+-- lemma at an equality motive, no η rule involved.
+def plus : ℕ → ℕ → ℕ
+  | plus Z n ≔ n
+  | plus (S m) n ≔ S (plus m n)
+
+-- the generated clause lemmas are ordinary accepted lemmas: an
+-- induction cites plusZ/plusS silently, through E's lemma source
+def plusZr : (n : ℕ) → plus n Z ≡ n ∈ ℕ
+  ≔ λn. ℕ-elim (x. plus x Z ≡ x ∈ ℕ) ⋆ (k ih. ⋆) n
+
+-- the uniqueness lemma is the recursor's universal property: any
+-- candidate satisfying the clauses IS plus — here a hand-written
+-- eliminator, its clause hypotheses paid by computation
+def plusByHand : ℕ → ℕ → ℕ ≔ λm. λn. ℕ-elim (x. ℕ) n (k ih. S ih) m
+def byHandIsPlus : (m : ℕ) (n : ℕ) → plusByHand m n ≡ plus m n ∈ ℕ
+  ≔ λm. λn. plusEta plusByHand (λx. ⋆) (λk. λx. ⋆) m n
+
+-- recursion at a CHANGED trailing argument is in the fragment: the
+-- Π-motive over the trailing columns makes the induction hypothesis
+-- a function
+def addAcc : ℕ → ℕ → ℕ
+  | addAcc Z n ≔ n
+  | addAcc (S m) n ≔ addAcc m (S n)
+
+-- ⊎ split (no recursion — ⊎-elim has no induction hypothesis)
+def swap : ℕ ⊎ 𝟙 → 𝟙 ⊎ ℕ
+  | swap (inj₁ n) ≔ inj₂ n
+  | swap (inj₂ u) ≔ inj₁ u
+
+-- the no-split form: a single all-variable clause
+def double : ℕ → ℕ
+  | double n ≔ plus n n
+
+-- an operator-named item has no identifier to prefix: every
+-- generated name is overridden
+infixl 6 ⊞
+def ⊞ : ℕ → ℕ → ℕ [oplusEta]
+  | Z ⊞ n ≔ n [oplusZ]
+  | S m ⊞ n ≔ S (m ⊞ n) [oplusS]
+
+-- the WITNESS form: existence supplied by hand, the clause lemmas
+-- paid with ⋆ (here by computation), uniqueness still synthesized —
+-- the eta proof rewrites by the clause lemmas, never by unfolding
+-- the witness
+def pred : ℕ → ℕ ≔ λn. ℕ-elim (x. ℕ) Z (k ih. k) n
+  | pred Z ≔ Z
+  | pred (S m) ≔ m

--- a/tests/nova/elaboration/elab-clauses-accept/expected
+++ b/tests/nova/elaboration/elab-clauses-accept/expected
@@ -1,0 +1,9 @@
+defined plus by clauses (plus, plusZ, plusS, plusEta)
+defined plusZr
+defined plusByHand
+defined byHandIsPlus
+defined addAcc by clauses (addAcc, addAccZ, addAccS, addAccEta)
+defined swap by clauses (swap, swapInl, swapInr, swapEta)
+defined double by clauses (double, doubleEq, doubleEta)
+defined ⊞ by clauses (⊞, oplusZ, oplusS, oplusEta)
+Accepted.

--- a/tests/nova/elaboration/elab-clauses-accept/input.nova
+++ b/tests/nova/elaboration/elab-clauses-accept/input.nova
@@ -1,0 +1,26 @@
+def plus : ℕ → ℕ → ℕ
+  | plus Z n ≔ n
+  | plus (S m) n ≔ S (plus m n)
+
+def plusZr : (n : ℕ) → plus n Z ≡ n ∈ ℕ
+  ≔ λn. ℕ-elim (x. plus x Z ≡ x ∈ ℕ) ⋆ (k ih. ⋆) n
+
+def plusByHand : ℕ → ℕ → ℕ ≔ λm. λn. ℕ-elim (x. ℕ) n (k ih. S ih) m
+def byHandIsPlus : (m : ℕ) (n : ℕ) → plusByHand m n ≡ plus m n ∈ ℕ
+  ≔ λm. λn. plusEta plusByHand (λx. ⋆) (λk. λx. ⋆) m n
+
+def addAcc : ℕ → ℕ → ℕ
+  | addAcc Z n ≔ n
+  | addAcc (S m) n ≔ addAcc m (S n)
+
+def swap : ℕ ⊎ 𝟙 → 𝟙 ⊎ ℕ
+  | swap (inj₁ n) ≔ inj₂ n
+  | swap (inj₂ u) ≔ inj₁ u
+
+def double : ℕ → ℕ
+  | double n ≔ plus n n
+
+infixl 6 ⊞
+def ⊞ : ℕ → ℕ → ℕ [oplusEta]
+  | Z ⊞ n ≔ n [oplusZ]
+  | S m ⊞ n ≔ S (m ⊞ n) [oplusS]

--- a/tests/nova/elaboration/elab-clauses-accept/run
+++ b/tests/nova/elaboration/elab-clauses-accept/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+"$1" elab input.nova

--- a/tests/nova/elaboration/elab-clauses-degrade/expected
+++ b/tests/nova/elaboration/elab-clauses-degrade/expected
@@ -1,0 +1,10 @@
+declared fib and its equations (fib, fibZ, fibS, fibEta) — clauses outside the structural fragment [+4 holes]
+open holes (4):
+  [fib] ⊢ ? : ℕ → ℕ
+      at: def fib
+  [fibZ] ⊢ ? : fib Z ≡ Z ∈ ℕ
+      at: def fibZ
+  [fibS] ⊢ ? : (n:ℕ) → Prf (fib (S n) ≡ fib (S n) ∈ ℕ)
+      at: def fibS
+  [fibEta] ⊢ ? : (x:ℕ → ℕ) → Prf (x Z ≡ Z ∈ ℕ) → ((n:ℕ) → Prf (x (S n) ≡ x (S n) ∈ ℕ)) → (n:ℕ) → Prf (x n ≡ fib n ∈ ℕ)
+      at: def fibEta

--- a/tests/nova/elaboration/elab-clauses-degrade/input.nova
+++ b/tests/nova/elaboration/elab-clauses-degrade/input.nova
@@ -1,0 +1,3 @@
+def fib : ℕ → ℕ
+  | fib Z ≔ Z
+  | fib (S m) ≔ fib (S m)

--- a/tests/nova/elaboration/elab-clauses-degrade/run
+++ b/tests/nova/elaboration/elab-clauses-degrade/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+"$1" elab input.nova

--- a/tests/nova/elaboration/elab-clauses-eta-obligation/expected
+++ b/tests/nova/elaboration/elab-clauses-eta-obligation/expected
@@ -1,0 +1,5 @@
+defined plus by clauses (plus, plusZ, plusS, plusEta)
+defined mul by clauses (mul, mulZ, mulS, mulEta) [+1 obligation]
+open obligations (1):
+  [1] (g : ℕ → ℕ → ℕ) (mulZ : (n:ℕ) → Prf (g Z n ≡ Z ∈ ℕ)) (mulS : (n:ℕ) → (m:ℕ) → Prf (g (S n) m ≡ plus m (g n m) ∈ ℕ)) (_ : ℕ) (m : ℕ) (ih : (n:ℕ) → Prf (g m n ≡ mul m n ∈ ℕ)) (_ : ℕ) ⊢ g (S m) _ ≐ mul (S m) _ : ℕ
+      at: def mulEta: checking ⋆

--- a/tests/nova/elaboration/elab-clauses-eta-obligation/input.nova
+++ b/tests/nova/elaboration/elab-clauses-eta-obligation/input.nova
@@ -1,0 +1,14 @@
+-- The eta synthesis's CURRENT engine boundary (see the "Defining
+-- equations" section of docs/NovaElaboration.txt): a recursive call
+-- nested under another application puts the induction-hypothesis
+-- rewrite inside an argument of a stuck eliminator spine, where
+-- equation replay's typed descent cannot determine the position's
+-- type. The definition and its clause lemmas accept; the uniqueness
+-- ⋆ stands as an ordinary obligation.
+def plus : ℕ → ℕ → ℕ
+  | plus Z n ≔ n
+  | plus (S m) n ≔ S (plus m n)
+
+def mul : ℕ → ℕ → ℕ
+  | mul Z n ≔ Z
+  | mul (S m) n ≔ plus n (mul m n)

--- a/tests/nova/elaboration/elab-clauses-eta-obligation/run
+++ b/tests/nova/elaboration/elab-clauses-eta-obligation/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+"$1" elab input.nova

--- a/tests/nova/elaboration/elab-clauses-missing-case/expected
+++ b/tests/nova/elaboration/elab-clauses-missing-case/expected
@@ -1,0 +1,8 @@
+declared pred and its equations (pred, predS, predEta) — clauses outside the structural fragment [+3 holes]
+open holes (3):
+  [pred] ⊢ ? : ℕ → ℕ
+      at: def pred
+  [predS] ⊢ ? : (n:ℕ) → Prf (pred (S n) ≡ n ∈ ℕ)
+      at: def predS
+  [predEta] ⊢ ? : (x:ℕ → ℕ) → ((n:ℕ) → Prf (x (S n) ≡ n ∈ ℕ)) → (n:ℕ) → Prf (x n ≡ pred n ∈ ℕ)
+      at: def predEta

--- a/tests/nova/elaboration/elab-clauses-missing-case/input.nova
+++ b/tests/nova/elaboration/elab-clauses-missing-case/input.nova
@@ -1,0 +1,2 @@
+def pred : ℕ → ℕ
+  | pred (S m) ≔ m

--- a/tests/nova/elaboration/elab-clauses-missing-case/run
+++ b/tests/nova/elaboration/elab-clauses-missing-case/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+"$1" elab input.nova

--- a/tests/nova/elaboration/elab-clauses-op-error/expected
+++ b/tests/nova/elaboration/elab-clauses-op-error/expected
@@ -1,0 +1,1 @@
+Error: def +: an operator-named item requires a [name] override on every clause

--- a/tests/nova/elaboration/elab-clauses-op-error/input.nova
+++ b/tests/nova/elaboration/elab-clauses-op-error/input.nova
@@ -1,0 +1,4 @@
+infixl 6 +
+def + : ℕ → ℕ → ℕ
+  | Z + n ≔ n
+  | S m + n ≔ S (m + n)

--- a/tests/nova/elaboration/elab-clauses-op-error/run
+++ b/tests/nova/elaboration/elab-clauses-op-error/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+"$1" elab input.nova

--- a/tests/nova/elaboration/elab-clauses-witness/expected
+++ b/tests/nova/elaboration/elab-clauses-witness/expected
@@ -1,0 +1,3 @@
+defined pred by clauses via witness (pred, predZ, predS, predEta)
+defined usePredS
+Accepted.

--- a/tests/nova/elaboration/elab-clauses-witness/input.nova
+++ b/tests/nova/elaboration/elab-clauses-witness/input.nova
@@ -1,0 +1,5 @@
+def pred : ℕ → ℕ ≔ λn. ℕ-elim (x. ℕ) Z (k ih. k) n
+  | pred Z ≔ Z
+  | pred (S m) ≔ m
+
+def usePredS : (m : ℕ) → pred (S m) ≡ m ∈ ℕ ≔ λm. ⋆

--- a/tests/nova/elaboration/elab-clauses-witness/run
+++ b/tests/nova/elaboration/elab-clauses-witness/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+"$1" elab input.nova

--- a/tests/nova/elaboration/parse-clauses/expected
+++ b/tests/nova/elaboration/parse-clauses/expected
@@ -1,0 +1,1 @@
+def plus : Pi _ (ℕ) (Pi _ (ℕ) (ℕ)) [pe] := Z | Z n := n@0 [pz] | S (m) n := S (App (App (plus@sig) (m@1)) (n@0))

--- a/tests/nova/elaboration/parse-clauses/run
+++ b/tests/nova/elaboration/parse-clauses/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+"$1" run surface-item "def plus : ℕ → ℕ → ℕ [pe] ≔ Z | plus Z n ≔ n [pz] | plus (S m) n ≔ S (plus m n)"


### PR DESCRIPTION
A `def` with clauses is a new ITEM MACRO asserting that its equations **determine** the definiendum — the solution space is contractible — and expanding into a batch of ordinary defs naming the three pieces of that assertion:

```
def plus : ℕ → ℕ → ℕ
  | plus Z n ≔ n
  | plus (S m) n ≔ S (plus m n)
```

* **existence** — `def plus ≔ ρ`, a synthesized eliminator body (the Π-motive over the trailing columns, so recursion at a changed later argument is in the fragment);
* **clause lemmas** — `plusZ`, `plusS`: the equations Π-closed over their pattern telescopes, bodies `⋆`, discharged by pure β in the fragment. Ordinary accepted lemmas afterwards: later inductions cite them silently, and conversions match them one-step instead of unfolding ρ;
* **uniqueness** — `plusEta`, the recursor's universal property stated pointwise, proven by the eliminator at the equality motive (kernel caveat A5's route — no η replay finals exist or are needed). The proof rewrites by the clause lemmas, never by unfolding the witness, so it is independent of where the witness came from.

Everything is elaborator-level: no Foundation rule and no kernel capability is added, and nothing about obligations, discharge, modules or the report is clause-aware.

**v1 structural fragment**: one split column, depth-1 patterns over ℕ and ⊎, linear LHSs, structural recursion. Outside it the item degrades, never walls: with a witness (`def f : T ≔ t | clauses`) the clause lemmas become ordinary `⋆`-payments; without one the whole batch demotes to declarations (the abstract-interface idiom). One semantics, three labor divisions.

Names are a pure function of the source (`plusZ`/`plusS`, `nInl`/`nInr`, `nEq`, `nEta`), overridable per clause and on the header with `[name]`; operator-named items must override. The clause marker `|` is withdrawn from the operator alphabet; the clause separator is `≔`, leaving `=` an ordinary operator token.

**Known engine boundary**, recorded in the spec and as a golden (`elab-clauses-eta-obligation`): a recursive call nested under another application (`mul (S m) n ≔ plus n (mul m n)`) puts the ih-rewrite at a position equation replay's typed descent cannot yet type (the constant-motive approximation), so the uniqueness `⋆` stands as an ordinary obligation while the definition and clause lemmas accept — the designed safe degradation. Widening the descent is future work; the gap predates this PR (plain hand-written code hits it too).

Also fixes, as a standalone commit, the surface grammar's omission of the declaration item form `def n : T` that `e-decl` had always specified.

Deferred, accommodated by the contract (new synthesis tactics, not new semantics): nested/multi-column splits, QIIT splits, copatterns via `corec`/`el-nu-coind`, strong induction, mutual blocks.

139/139 golden tests, 27/27 corpus elaborations; `src/nova/definingEq.nova` exercises the accepted shapes end to end, including applying `plusEta` to prove a hand-written eliminator equal to `plus`.