### PR TITLE
The neutral-subterm rule: typed descent through motive-less positions

### DIFF
--- a/docs/NovaElaboration.txt
+++ b/docs/NovaElaboration.txt
@@ -853,7 +853,19 @@ whnf(C) = Prf ∥A∥        Γ ⊢ e ⇐ A ⇝ ê
 #        a₀ , b₀   ≐ a₁ , b₁    ⇐  componentwise at the Σ-type
 #        neutral spines with the same head variable/eliminator:
 #                                  componentwise (app-cong, proj-cong,
-#                                  ℕ-elim-cong, quot-elim-cong)
+#                                  ℕ-elim-cong, quot-elim-cong). When
+#                                  the shared head is a STUCK
+#                                  ELIMINATOR its type is not
+#                                  inferable (bare core carries no
+#                                  motive), so the argument components
+#                                  are compared at an UNDETERMINED
+#                                  type: rewriting is type-blind, and
+#                                  the kernel validates every emitted
+#                                  step positionally — at such
+#                                  positions by the NEUTRAL-SUBTERM
+#                                  rule (docs/NovaKernel.txt §6) — so
+#                                  a wrong guess is a failed replay,
+#                                  never a wrong acceptance.
 #   4. Mixed El: whnf leaves `El a` (a neutral) against a rigid type B.
 #      When B is in the image of El-decoding with codable components
 #      (𝟘, 𝟙, ℕ, arrows/pairs/quotients/eq of codable parts), reduce to
@@ -1267,16 +1279,15 @@ pointwise, exhibit that g satisfies the clauses.
 # pipeline as every ℕ-elim proof; if the engine ever misses, the
 # residue is an ordinary obligation, never a wrong acceptance.
 #
-# One such miss is CURRENT, recorded by a golden test
-# (elab-clauses-eta-obligation): a recursive call NESTED under
-# another application — mul's  plus n (mul m n)  — puts the
-# ih-rewrite inside an argument of a stuck eliminator spine, a
-# position whose expected type equation replay's typed descent
-# cannot yet determine (the constant-motive approximation,
-# docs/NovaPipeline.txt "Status"). The definition and its clause
-# lemmas still accept; only the uniqueness ⋆ stands, as an ordinary
-# obligation. Widening the descent — the argument position's type is
-# the head's synthesizable domain — is engine/kernel future work.
+# A recursive call NESTED under another application — mul's
+# plus n (mul m n) — exercises exactly this residue-not-wall
+# machinery's outer edge: the ih-rewrite lands inside an argument of
+# a stuck eliminator spine, a position whose expected type the
+# descent cannot determine. It discharges through the
+# NEUTRAL-SUBTERM rule (docs/NovaKernel.txt §6 — the argument being
+# rewritten types itself) plus the unknown-type congruence descent
+# (step 3 of the ↓ loop); the golden elab-clauses-eta-obligation
+# pins the shape.
 
 # OUTSIDE THE FRAGMENT (deeper patterns, another split type, several
 # split columns, a missing or duplicated constructor, non-structural
@@ -1476,7 +1487,4 @@ Two corollaries worth keeping in view while implementing:
   (out (f x̄) ≔ …) compiling to corec, uniqueness by el-nu-coind
   with the graph invariant as the bisimulation; strong induction /
   course-of-values as an alternative existence synthesis; mutual
-  blocks as a single QIIT elimination problem. ENGINE: typed descent
-  through neutral-application arguments, so a NESTED recursive call
-  (mul-shape) discharges its uniqueness ⋆ — today that ⋆ stands as
-  an ordinary obligation (elab-clauses-eta-obligation).
+  blocks as a single QIIT elimination problem.

--- a/docs/NovaKernel.txt
+++ b/docs/NovaKernel.txt
@@ -248,9 +248,11 @@ el-sigma-e₁/₂ and the ℕ/𝟙 introductions:
   -----------------------------
   Σ; Γ ⊦ t.π₁ ⇒ᵖ A
 
-  Σ; Γ ⊦ () ⇒ᵖ 𝟙      Σ; Γ ⊦ Z ⇒ᵖ ℕ      Σ; Γ ⊦ t ⇐ᵖ ℕ
-                                          ---------------
-                                          Σ; Γ ⊦ S t ⇒ᵖ ℕ
+  Σ; Γ ⊦ () ⇒ᵖ 𝟙      Σ; Γ ⊦ Z ⇒ᵖ ℕ
+
+                      Σ; Γ ⊦ t ⇐ᵖ ℕ
+                      ---------------
+                      Σ; Γ ⊦ S t ⇒ᵖ ℕ
 
 Universe CODES infer at 𝕌 (components checked at their code types) —
 a generic lemma's 𝕌-parameter materialized at a concrete code is a
@@ -631,10 +633,23 @@ Checking  Σ; Γ ⊦ t ⇐ T ⟨sk⟩ :
      replay 𝒞 ▷ T′ ≐ T. (The conversion is CERTIFIED, never decided
      by the kernel.)
   2. Otherwise, if sk carries expose T′ 𝒞: replay 𝒞 ▷ T ≐ T′ and
-     continue checking at T′. (T′'s well-formedness follows from T's
-     by the certified equality; the intro checks against the exposed
-     head and coercion — judgementally the identity — transports the
-     result. This is PExpose; its equation-level twin is the bridge.)
+     continue checking at T′. (No formation check of T′ precedes the
+     replay, and none is needed: replay is EXTRINSIC — spelling
+     surgery presupposing neither side — both sides entering as bare
+     syntax, each step's license carrying its own components'
+     typedness (the proof's ⇒ᵖ-inferred Prf-type presupposes the
+     equation's sides). Read declaratively it is a CONDITIONAL:
+     given Γ ⊦ T type — an invariant of this pass, every expected
+     type being built from the item's checked type by nf and
+     structural decomposition — a successful replay makes nf(T′) a
+     well-formed type ≐ T. And nf(T′) is all the continuation
+     consumes: step 3 normalizes before matching the head, so the
+     intro checks against the exposed head and coercion —
+     judgementally the identity — transports the result. Raw T′ is
+     never established well-formed (≜-expansion does not reflect
+     formation) and never needs to be: it is a REPRESENTATIVE, like
+     every annotation. This is PExpose; its equation-level twin is
+     the bridge, where the same conditional reading applies.)
   3. Then by the head of t:
 
      nf(T) ⇓ A → B    Σ; Γ ▷ A ⊦ f ⇐ B ⟨sk.0⟩

--- a/docs/NovaKernel.txt
+++ b/docs/NovaKernel.txt
@@ -428,13 +428,39 @@ equation's type in situ at the rewrite point:
     ------------------------------------------------
     u rewrites to r[↑ᵇ]
 
-  at path end with expected type UNDETERMINED: reject.
+  at path end with expected type UNDETERMINED, no binders crossed
+  (b = 0), and the subterm a NEUTRAL with a ⇒ᴺ-synthesizable type
+  (the NEUTRAL-SUBTERM rule):
+    nf(⇒ᴺ(u)) = nf(A)     # the licensed type matches the SUBTERM
+    u = l
+    ------------------------------------------------
+    u rewrites to r
+
+  at path end with expected type UNDETERMINED otherwise: reject.
 
 An expected type is undetermined at positions whose type only a
 motive or a non-normal spelling would determine; that is harmless at
 positions merely passed THROUGH (an intermediate hop of the path
-needs no type — congruence demands nothing there) and fatal only at
-the rewrite point itself. The child-type table (parent's expected
+needs no type — congruence demands nothing there) and consequential
+only at the rewrite point itself.
+
+THE NEUTRAL-SUBTERM RULE, justified. At a type-undetermined rewrite
+point the positional check may be paid by the subterm instead: any
+type a neutral inhabits is judgementally equal to its ⇒ᴺ-type — a
+typing INVERSION (a neutral's typings factor through its head's
+declared type plus conversion; no other rule types a variable- or
+reference-headed spine) — so the position's expected type, whatever
+it is, converts to nf(⇒ᴺ(u)), and the congruence instance is
+licensed at it. The multi-typing that makes the positional check
+load-bearing lives at INTRO forms (a class spelling inhabits every
+quotient that relates its representative), and ⇒ᴺ refuses intro
+heads — the historical exploits stay dead. Binder-crossing paths are
+excluded because the descent does not track crossed binders' types
+(the subterm's variables could not be resolved against Γ); that
+residue is an approximation in A1's spirit. The rule is what lets a
+rewrite land inside an ARGUMENT of a stuck eliminator spine — the
+head's type needs the lost motive, but the argument being rewritten
+is typically a variable-headed spine that types itself. The child-type table (parent's expected
 type E; — means undetermined):
 
   𝟘-elim t        child 0 : 𝟘

--- a/docs/NovaKernel.txt
+++ b/docs/NovaKernel.txt
@@ -248,7 +248,9 @@ el-sigma-e₁/₂ and the ℕ/𝟙 introductions:
   -----------------------------
   Σ; Γ ⊦ t.π₁ ⇒ᵖ A
 
-  Σ; Γ ⊦ () ⇒ᵖ 𝟙      Σ; Γ ⊦ Z ⇒ᵖ ℕ      Σ; Γ ⊦ t ⇐ᵖ ℕ ⇒ S t ⇒ᵖ ℕ
+  Σ; Γ ⊦ () ⇒ᵖ 𝟙      Σ; Γ ⊦ Z ⇒ᵖ ℕ      Σ; Γ ⊦ t ⇐ᵖ ℕ
+                                          ---------------
+                                          Σ; Γ ⊦ S t ⇒ᵖ ℕ
 
 Universe CODES infer at 𝕌 (components checked at their code types) —
 a generic lemma's 𝕌-parameter materialized at a concrete code is a

--- a/docs/NovaPipeline.txt
+++ b/docs/NovaPipeline.txt
@@ -232,7 +232,10 @@ exhaustion = reject), proof-element inference/checking for elimination
 spines and intro forms, injectivity selectors, TYPED PATH DESCENT
 (every rewrite's licensed equation is verified against its position's
 locally determined expected type — intermediate hops need no type,
-congruence only demands the child equation at the rewrite point), and
+congruence only demands the child equation at the rewrite point, and
+a type-undetermined rewrite point accepts a neutral subterm at its
+own synthesized type, the NEUTRAL-SUBTERM rule of the kernel spec's
+§6), and
 replay of the certificate finals (beta, el-zero-prop/el-one-prop,
 quotient witnesses, el-pi-eta/el-sigma-eta). The discharge engine emits certificates for every discharge
 (rewrite traces with parametric-context normalization bridging,

--- a/src/idris/Nova/Elaboration.idr
+++ b/src/idris/Nova/Elaboration.idr
@@ -1454,7 +1454,16 @@ mutual
       then case betaTy st.sig <$> inferNe st ctx f of
              Just (Ty.PiTy dom _) =>
                prefixSteps 1 <$> (spEqElemC dep st cs ctx x y dom >>= flatSteps)
-             _ => Nothing
+             _ =>
+               -- the shared head is a stuck eliminator: bare core
+               -- carries no motive, so the argument's type is not
+               -- inferable. Compare the arguments at an UNKNOWN type
+               -- anyway — rewriting is type-blind, and the kernel
+               -- validates every emitted step against its position
+               -- (the neutral-subterm rule, NovaKernel.txt §6), so a
+               -- wrong guess is a failed replay, never a wrong
+               -- acceptance.
+               prefixSteps 1 <$> (spEqElemC dep st cs ctx x y Ty.NatTy >>= flatSteps)
       else Nothing
   spCongC dep st cs ctx (SigmaElim1 u) (SigmaElim1 v) =
     case inferNe st ctx u of

--- a/src/idris/Nova/Kernel.idr
+++ b/src/idris/Nova/Kernel.idr
@@ -1243,15 +1243,31 @@ goTy : Sig -> Ctx -> (Elem, Elem, Ty) -> List Nat -> Nat -> Ty -> KM Ty
 ||| against each position's expected type.
 goE : Sig -> Ctx -> (Elem, Elem, Ty) -> List Nat -> Nat -> Maybe Ty -> Elem -> KM Elem
 goE sig ctx lic@(le, re, ltyN) [] b mexp u = do
-  case mexp of
-    Nothing => kerr "kernel: step at a type-undetermined position"
-    Just expTy => do
-      expN <- kTy sig expTy
-      if expN /= weakenTyN b ltyN
-        then kerr "kernel: step type does not match the position"
-        else if u == weakenN b le
-          then pure (weakenN b re)
-          else kerr "kernel: step does not match the subterm"
+  expN <- case mexp of
+    Just expTy => kTy sig expTy
+    Nothing =>
+      -- the NEUTRAL-SUBTERM rule (spec §6): at a type-undetermined
+      -- rewrite point, the subterm's own ⇒ᴺ-type serves in the
+      -- positional check — any type a neutral inhabits is
+      -- judgementally equal to its synthesized type (typing
+      -- inversion: a neutral's typings factor through its head's
+      -- declared type plus conversion; the multi-typing the check
+      -- guards against lives at INTRO forms, which ⇒ᴺ refuses).
+      -- Binder-crossing paths are excluded: the crossed binders'
+      -- types are untracked here, so the subterm's variables could
+      -- not be resolved against ctx.
+      if b == 0
+        then do
+          mu <- inferNeK sig ctx u
+          case mu of
+            Just uTy => kTy sig uTy
+            Nothing => kerr "kernel: step at a type-undetermined position"
+        else kerr "kernel: step at a type-undetermined position"
+  if expN /= weakenTyN b ltyN
+    then kerr "kernel: step type does not match the position"
+    else if u == weakenN b le
+      then pure (weakenN b re)
+      else kerr "kernel: step does not match the subterm"
 goE sig ctx lic (i :: p) b mexp u = do
   childTy <- childTyE sig ctx mexp u i
   let goQSpine : SubNorm -> (SubNorm -> Elem) -> KM Elem

--- a/src/nova/definingEq.nova
+++ b/src/nova/definingEq.nova
@@ -55,3 +55,11 @@ def ⊞ : ℕ → ℕ → ℕ [oplusEta]
 def pred : ℕ → ℕ ≔ λn. ℕ-elim (x. ℕ) Z (k ih. k) n
   | pred Z ≔ Z
   | pred (S m) ≔ m
+
+-- a recursive call NESTED under another application: mulEta's
+-- ih-rewrite lands inside an argument of a stuck eliminator spine —
+-- discharged through the kernel's NEUTRAL-SUBTERM rule
+-- (docs/NovaKernel.txt §6) and the unknown-type congruence descent
+def mul : ℕ → ℕ → ℕ
+  | mul Z n ≔ Z
+  | mul (S m) n ≔ plus n (mul m n)

--- a/tests/nova/elaboration/elab-clauses-eta-obligation/expected
+++ b/tests/nova/elaboration/elab-clauses-eta-obligation/expected
@@ -1,5 +1,3 @@
 defined plus by clauses (plus, plusZ, plusS, plusEta)
-defined mul by clauses (mul, mulZ, mulS, mulEta) [+1 obligation]
-open obligations (1):
-  [1] (g : ℕ → ℕ → ℕ) (mulZ : (n:ℕ) → Prf (g Z n ≡ Z ∈ ℕ)) (mulS : (n:ℕ) → (m:ℕ) → Prf (g (S n) m ≡ plus m (g n m) ∈ ℕ)) (_ : ℕ) (m : ℕ) (ih : (n:ℕ) → Prf (g m n ≡ mul m n ∈ ℕ)) (_ : ℕ) ⊢ g (S m) _ ≐ mul (S m) _ : ℕ
-      at: def mulEta: checking ⋆
+defined mul by clauses (mul, mulZ, mulS, mulEta)
+Accepted.

--- a/tests/nova/elaboration/elab-clauses-eta-obligation/input.nova
+++ b/tests/nova/elaboration/elab-clauses-eta-obligation/input.nova
@@ -1,10 +1,9 @@
--- The eta synthesis's CURRENT engine boundary (see the "Defining
--- equations" section of docs/NovaElaboration.txt): a recursive call
--- nested under another application puts the induction-hypothesis
--- rewrite inside an argument of a stuck eliminator spine, where
--- equation replay's typed descent cannot determine the position's
--- type. The definition and its clause lemmas accept; the uniqueness
--- ⋆ stands as an ordinary obligation.
+-- A recursive call NESTED under another application: the uniqueness
+-- proof's ih-rewrite lands inside an argument of a stuck eliminator
+-- spine — a type-undetermined position, discharged through the
+-- NEUTRAL-SUBTERM rule (docs/NovaKernel.txt §6) plus the
+-- unknown-type congruence descent (docs/NovaElaboration.txt, step 3
+-- of the ↓ loop). This golden pins the shape.
 def plus : ℕ → ℕ → ℕ
   | plus Z n ≔ n
   | plus (S m) n ≔ S (plus m n)


### PR DESCRIPTION
Closes the engine/kernel boundary recorded by the defining-equations work: a recursive call **nested under another application** (`mul (S m) n ≔ plus n (mul m n)`) left its uniqueness `⋆` as an undischargeable obligation, because the ih-rewrite lands inside an argument of a stuck eliminator spine — a position whose expected type needs the motive that bare core deliberately doesn't carry. The same wall blocked plain hand-written congruence rewrites (`plus x a ≐ plus x b` from `a ≡ b` failed certificate replay).

Two composing changes, spec'd first (NovaKernel.txt §6, NovaElaboration.txt step 3 of the ↓ loop), then implemented:

**Kernel — the NEUTRAL-SUBTERM rule.** At a type-undetermined rewrite point with no binders crossed, the positional check may be paid by the *subterm*: any type a neutral inhabits is judgementally equal to its synthesized spine type (typing inversion — a neutral's typings factor through its head's declared type plus conversion). The multi-typing the positional check guards against lives at **intro** forms (a `class` spelling inhabits every quotient that relates its representative), and `⇒ᴺ` refuses intro heads — both historical exploits stay dead. The insight that makes the mul-shape work: the *head*'s type needs the lost motive, but the *argument* being rewritten is a variable-headed spine that types itself.

**Engine — unknown-type congruence descent.** Neutral-spine congruence through a shared stuck-eliminator head now compares the argument components at an undetermined type: rewriting is type-blind, and every emitted step is validated positionally at replay, so a wrong guess is a failed replay, never a wrong acceptance. The existing hop mechanism then assembles the full chain (g-clause hypothesis at the root — a determined position — then the ih-rewrite at the nested call under the new rule).

`elab-clauses-eta-obligation` flips from one standing obligation to Accepted and now pins the shape as a regression test; `src/nova/definingEq.nova` gains `mul`. The defining-equations section's boundary note becomes a description of the mechanism and the future-work engine bullet is retired. Binder-crossing paths still reject (crossed binders' types are untracked in the descent), recorded as an approximation in A1's spirit.

Also two spec-precision fixes found while reading: the proof-spine S-inference rule is now stated with the standard natural-deduction bar (its one-liner spelling used a bare ⇒ as meta-implication one superscript away from ⇒ᵖ), and PExpose's well-formedness parenthetical is restated as the conditional it actually is — replay is extrinsic, `nf(T′)` (not raw T′) becomes well-formed given `Γ ⊦ T type`, and `nf(T′)` is all the continuation consumes.

139/139 golden tests, 27/27 corpus elaborations.