### PR TITLE
Judgment-carrying elaboration (stacked on the derivation rework)

### DIFF
--- a/docs/NovaDerivations.txt
+++ b/docs/NovaDerivations.txt
@@ -288,6 +288,34 @@ the route exists to avoid. beta-at is the exposure link: free of
 premises beyond the rolling typing witness, a chain of them costs
 the replay one contraction each.
 
+////////// Admissible addition 3: sharing //////////
+
+Derivations are DAGs in practice — one judgment's derivation feeds
+many premises — but the format is a tree, so replay walks a shared
+subderivation once per citation. At item scale this is not a
+constant: a body assembled from stored derivations embedded per use
+went out of replay fuel on real corpus input. The remedy is sharing
+made EXPLICIT in the artifact, not a cache in the checker:
+
+  Δ ⊦ D₀ ⇓ J₀        Γ ⊦ D₁ ⇓ J     (⟨i⟩ in D₁ cites (Δ, J₀))
+  ------------------------------------------------------------ (share)
+  Γ ⊦ share Δ D₀ D₁ ⇓ J
+
+  ---------------------------------------------- (share-ref)
+  Γ ⊦ ⟨i⟩ ⇓ Jᵢ        # legal exactly at Γ = Δᵢ
+
+The environment of bindings is an INPUT of replay, like the context;
+indices are absolute, outermost binding first. A citation is legal
+exactly at the binding's context — judgments do not weaken silently;
+reuse under a binder must pass through explicit rules. The carried Δ
+is payload, like an eliminator's motive.
+
+Justification: a citation replays nothing and asserts nothing new —
+it uses a judgment the SAME replay run already concluded, exactly as
+a Σ reference uses an accepted item's. In the setoid model, share is
+an ordinary let. conclude stays cache-free: sharing is visible in
+the artifact, auditable, and preserved by export.
+
 ////////// Rule-by-rule: demands and deliveries //////////
 
 Mechanically derivable from Foundation's statements by the delivery

--- a/docs/NovaPipeline.txt
+++ b/docs/NovaPipeline.txt
@@ -951,10 +951,25 @@ base and every A-caveat with it.
      eliminator's ℕ, a Π's just-constructed domain) — and the
      ty-sig formation route writes a type hole's formation from it,
      the sub-norm premise chain read straight off the judgment
-     context (hole-typed eliminator motives now construct). Not yet
-     ported, in order of value: the CONVERSION COERCION at the
-     switch — every remaining gate failure in the corpus is this
-     one wall (an inferred ℕ against a hole-spelled expected type;
-     it needs convTy's certificate as a derivation, i.e. the
-     refiner's seed) — then exposure sites, pairs/projections/let,
-     and hole references in element position.]
+     context (hole-typed eliminator motives now construct). A third increment ports
+     the SWITCH COERCION — different spellings coerce along nf-eq of
+     the two formations already in hand (the inferred side's by
+     presupposition, the expected side's threaded), an optimistic
+     node that concludes whenever the types are nf-equal AT
+     CONSUMPTION, i.e. post-hole-solving; a conversion true only by
+     a rewrite lemma stays for the refiner. With it the
+     computational eliminators compose end to end. A fourth ports
+     HOLE USES (el-sig with the sub-norm chain read off the judgment
+     context — every proof spine's hole arguments) and PAIRS (the
+     second component's expected formation is one substitution wrap
+     over the Σ's inverted codomain). Measured after all four:
+     83–468 constructed judgments per corpus file. Cost, honestly:
+     the meter sits at ~84s (from ~42s) — the flood of stored
+     constructed entries each pays one consumption-time validation,
+     the mid-port triple-walk cost the end-state deletes; a
+     Σ-length-keyed failure cache already stops re-validation of
+     entries whose holes have not solved yet, and validation
+     batching is the next lever if the meter matters before the
+     erased routes start retiring. Remaining routes: ⋆-discharge
+     (the certificate as a derivation — the refiner), exposure
+     sites, projections/let, eliminators beyond ℕ.]

--- a/docs/NovaPipeline.txt
+++ b/docs/NovaPipeline.txt
@@ -749,6 +749,44 @@ Phasing:
      it — the instances it consumes are exactly the witnesses
      judgment-carrying elaboration would have in hand.]
 
+    [Tenth slice, the DERIVATION WALK: placement machinery reads its
+     premises off a rolling structural witness instead of
+     reconstructing them. The chain carries, beside the compact
+     presupposition witness, a STRUCTURAL one: seeded per side (the
+     by-term store, else one plain inference under its own
+     allowance), transformed per exposure by constructive subject
+     reduction (stepTypedE: one ≜ contraction ON the derivation —
+     β from the λ's own premises, ℕ-elim from the branches, SigVar
+     unfold by substituting into the recorded body derivation), and
+     read by rePlaceE's ZIPPER routes (Π-app both slots, pair
+     second slot, ℕ-elim scrutinee — the MOTIVE is a premise read,
+     never a guess). Premise access as projection arrives early:
+     dvView projects a side's typing out of the equation's own
+     congruence skeleton (presup-of-cong views, presup-of-beta-at
+     via the walk), so the placement's own conclusion re-seeds the
+     witness after each rewrite. Accepted items record their body
+     derivations by name (share-free re-emission for small bodies —
+     a DShare citation cannot be walked — plus an on-demand lazy
+     record for residue-accepted solutions). Around the walk, the
+     bridge machinery gained what the pool recordings cannot give:
+     nf'd variants of recorded instances, ∀-re-instantiation by
+     first-order MATCHING of a lemma's nf'd statement sides against
+     the pair (enumeration cannot reach a three-argument tuple),
+     closed SIGNATURE laws as instance sources (no recorded-context
+     skew), and one-sided rewrites at any occurrence within any
+     disagreement prefix, backtracking across candidates under the
+     fuel bound and the memo. Result: the S-instance's FIRST
+     placement — the eighth slice's wall — goes through end to end,
+     bridge included. What stands is one level deeper again: the
+     SECOND placement's witness view crosses a position the first
+     rewrite shifted, where the β-substitution inside the walk
+     needs the propositional index bridge itself — the walk's
+     typing-rule exactness meets the same shift the equation rules
+     absorb in their conclusion instances. The residue holds at
+     26/27 (suite 140/140, meter ~35s); every mechanism above is
+     permanent judgment-carrying substance, not stopgap — the
+     witness IS the Jud the end-state elaborator will carry.]
+
 ////////// Phase 3 end-state, revised: judgment-carrying elaboration //////////
 
 The eighth slice's last gap (the dependent-shift composite) forced

--- a/docs/NovaPipeline.txt
+++ b/docs/NovaPipeline.txt
@@ -785,7 +785,16 @@ Phasing:
      absorb in their conclusion instances. The residue holds at
      26/27 (suite 140/140, meter ~35s); every mechanism above is
      permanent judgment-carrying substance, not stopgap — the
-     witness IS the Jud the end-state elaborator will carry.]
+     witness IS the Jud the end-state elaborator will carry. A
+     follow-up adds the THREE-WAY FIT (fitEntry/fitNode): a stepped
+     or spliced premise coerced to the exact spelling its enclosing
+     node demands — identical spellings pass, nf-equal ones ride
+     nf-eq, a REAL index shift rides the license pool through
+     lemBridgeT with the ambient context threaded (dropped at
+     binders). The remaining gap, precisely: the shifted β's next
+     domain compares El-tower-at-stuck-index against the unfolded
+     Σ-form spelled one binder deeper — an El-vs-former bridge with
+     a context skew the fit does not yet reconcile.]
 
 ////////// Phase 3 end-state, revised: judgment-carrying elaboration //////////
 

--- a/docs/NovaPipeline.txt
+++ b/docs/NovaPipeline.txt
@@ -944,10 +944,17 @@ base and every A-caveat with it.
      is read optimistically. Measured coverage-by-construction:
      81–238 stored judgments per corpus file that reconstruction
      previously served (or failed to); suite and meter unchanged
-     (140/140, 26/27 at ~42s). Not yet ported, in likely order of
-     value: the ty-sig formation (hole-headed motive ambients — the
-     one gate all twelve nat.nova eliminator motives fail on),
-     exposure sites, the conversion coercion at the switch (needs
-     convTy's certificate as a derivation — the refiner's seed),
-     pairs/projections/let, and hole references in element
-     position.]
+     (140/140, 26/27 at ~42s). A second increment threads
+     the INTRINSIC CONTEXT: alongside the erased context, `jctx`
+     carries each binder's formation derivation where the pushing
+     route had it in hand (a λ's domain by inversion, an
+     eliminator's ℕ, a Π's just-constructed domain) — and the
+     ty-sig formation route writes a type hole's formation from it,
+     the sub-norm premise chain read straight off the judgment
+     context (hole-typed eliminator motives now construct). Not yet
+     ported, in order of value: the CONVERSION COERCION at the
+     switch — every remaining gate failure in the corpus is this
+     one wall (an inferred ℕ against a hole-spelled expected type;
+     it needs convTy's certificate as a derivation, i.e. the
+     refiner's seed) — then exposure sites, pairs/projections/let,
+     and hole references in element position.]

--- a/docs/NovaPipeline.txt
+++ b/docs/NovaPipeline.txt
@@ -798,14 +798,26 @@ Phasing:
      (structural descent preserving the rewrite-chain fuel, refl
      where a component already agrees, instances under binders
      supplied by the context-robust signature-law matcher after the
-     empty-recordings bail learned to defer to proposals). What
-     remains is the COMPOSITION of those closures inside one
-     fitNode call on the partially-applied function's Π-tower: each
-     leg closes in isolation, and the assembled search still
-     declines — an exploration-ordering residue in the legacy
-     replay's bridge, not a missing rule. The corner is exactly the
-     class of reconciliation the judgment-carrying port dissolves:
-     a witness carried from birth is spelled right by construction.]
+     empty-recordings bail learned to defer to proposals). A further
+     round closed the composition too: the empty-recordings bail
+     defers to the signature-law matcher on SMALL pairs (the
+     under-binder components where recordings cannot instantiate —
+     the license pool is also restored across nested replays now,
+     as the witness already was), the bridge carries the endpoints'
+     FORMATIONS down the Π/Σ descent (a refl leg must not re-derive
+     a normalized eliminator code's formation — the motive-guessing
+     wall, met again one level down), and the walk's defensive
+     concludes run at a separate VALIDATION FUEL with fuel-death a
+     soft verdict (a fitted composite can out-fuel a check without
+     being wrong; the megastep attempts were a measured 3x on the
+     meter). With all of that the S-case chain WALKS END TO END —
+     every exposure and both placements' witnesses. What remains is
+     the second placement's leaf: its licensed spelling meets the
+     chain's at a type whose nf blows past every allowance, the
+     last un-walked reconstruction in the file. The corner is
+     exactly the class of reconciliation the judgment-carrying port
+     dissolves: a witness carried from birth is spelled right by
+     construction.]
 
 ////////// Phase 3 end-state, revised: judgment-carrying elaboration //////////
 

--- a/docs/NovaPipeline.txt
+++ b/docs/NovaPipeline.txt
@@ -791,10 +791,21 @@ Phasing:
      node demands — identical spellings pass, nf-equal ones ride
      nf-eq, a REAL index shift rides the license pool through
      lemBridgeT with the ambient context threaded (dropped at
-     binders). The remaining gap, precisely: the shifted β's next
-     domain compares El-tower-at-stuck-index against the unfolded
-     Σ-form spelled one binder deeper — an El-vs-former bridge with
-     a context skew the fit does not yet reconcile.]
+     binders). The El-vs-former leg of that gap now closes (the
+     El-vs-former clause gained the nf'd and match-proposed
+     instances the El/El clause already had, plus its mirror
+     orientation), and lemBridgeT walks Π/Σ towers component-wise
+     (structural descent preserving the rewrite-chain fuel, refl
+     where a component already agrees, instances under binders
+     supplied by the context-robust signature-law matcher after the
+     empty-recordings bail learned to defer to proposals). What
+     remains is the COMPOSITION of those closures inside one
+     fitNode call on the partially-applied function's Π-tower: each
+     leg closes in isolation, and the assembled search still
+     declines — an exploration-ordering residue in the legacy
+     replay's bridge, not a missing rule. The corner is exactly the
+     class of reconciliation the judgment-carrying port dissolves:
+     a witness carried from birth is spelled right by construction.]
 
 ////////// Phase 3 end-state, revised: judgment-carrying elaboration //////////
 

--- a/docs/NovaPipeline.txt
+++ b/docs/NovaPipeline.txt
@@ -918,3 +918,36 @@ Cost, stated honestly: until phase 3 completes, an item is walked
 three times (elaborate, reconstruct, replay) — a constant factor,
 bought back by deleting the reconstruction frontier from the trusted
 base and every A-caveat with it.
+
+    [The port, first slice — the spine speaks Jud. Parallel
+     judgment-carrying entry points (inferElemJ / checkElemJ /
+     elabTyJ) own the ported routes and recurse through themselves,
+     delegating whole subtrees to the erased elaborator at unported
+     nodes; the def item's type and body enter through them. Ported
+     so far: variables, closed signature references, ℕ-constructors,
+     𝟙-intro, application (function inferred to a LITERAL Π — the
+     rewrite-normalizer exposure drops the judgment, its port needs
+     the certificate as a derivation), λ (the expected type's
+     formation threaded from the caller: an application's domain by
+     inversion, a def's type by its own construction), ℕ-elim (the
+     motive's formation constructed by elabTyJ, the branch instances
+     by one substitution wrap each), the equal-type switch, and the
+     formations Π/Σ/El/Prf/≡-as-Prf plus the nullary primitives. A
+     ported route CONSTRUCTS its judgment from sub-judgments — one
+     node per rule, premises in hand — and stores the derivation in
+     the same stores the births fill, where the emission pass
+     already consumes them; every composition is gated on the cached
+     erasures agreeing with the erased flow's spellings, so a ported
+     judgment never changes what elaboration produces, only what it
+     KNOWS. Pre-mirror hole references are fine: the judgment is
+     untrusted and validated at consumption, so the formation store
+     is read optimistically. Measured coverage-by-construction:
+     81–238 stored judgments per corpus file that reconstruction
+     previously served (or failed to); suite and meter unchanged
+     (140/140, 26/27 at ~42s). Not yet ported, in likely order of
+     value: the ty-sig formation (hole-headed motive ambients — the
+     one gate all twelve nat.nova eliminator motives fail on),
+     exposure sites, the conversion coercion at the switch (needs
+     convTy's certificate as a derivation — the refiner's seed),
+     pairs/projections/let, and hole references in element
+     position.]

--- a/nova.ipkg
+++ b/nova.ipkg
@@ -14,6 +14,7 @@ modules = Nova.Kernel.Syntax
         , Nova.Kernel.Derivation
         , Nova.Kernel.Reconstruct
         , Nova.Compute
+        , Nova.Elaboration.Jud
         , Nova.Elaboration.Named
         , Nova.Elaboration
         , Nova.Elaboration.Surface

--- a/src/idris/Nova/Elaboration.idr
+++ b/src/idris/Nova/Elaboration.idr
@@ -162,7 +162,6 @@ record ElabSt where
   ||| an accepted item the reconstructor cannot cover becomes an
   ||| error instead of a silent fallback
   strictDeriv : Bool
-
 initSt : ElabSt
 initSt = MkElabSt [<] [<] [] [] [] [<] [<] [<] [<] "" [<] False
 
@@ -2090,7 +2089,10 @@ mutual
     let cs = mkCandSet st ctx
     let mcert = spEqTyC spDepth st cs ctx tyA tyB
     case map (\cert => (cert, kCheckEqTy st.sig ctx kernelFuel cert tyA tyB)) mcert of
-      Just (cert, Right ()) => pure (Right cert)
+      Just (cert, Right ()) => do
+        mirrorHoleDefs
+        st' <- getSt
+        pure (Right (birthTyEqDeriv st'.kernelSig ctx cert tyA tyB))
       Just (_, Left kerrMsg) => pure (Left (site ++ " [replay failed: " ++ kerrMsg ++ "]"))
       Nothing => pure (Left site)
 

--- a/src/idris/Nova/Elaboration.idr
+++ b/src/idris/Nova/Elaboration.idr
@@ -3089,7 +3089,9 @@ mutual
         recordBinder br ctx env bn b
         (r', rSk) <- checkElem (ctx :< b) (env :< bn) site r
                        (substTy motTy (Ext Wk (Inj2 (CtxVar 0))))
-        pure (SumElim l' r' t', substTy motTy (Ext Id t'),
+        mirrorHoleDefs
+        stB <- getSt
+        pure (birthSumE stB.kernelSig ctx a b motTy l' r' t', substTy motTy (Ext Id t'),
               Nd [PMotive motTy motSk] [lSk, rSk, tSk])
       Nothing => throw "\{site}: ⊎-elim scrutinee has non-⊎ type\{structuralHint}"
   inferElem ctx env site (SQuotElim (zn, zr) mot (an, ar) f q) = do
@@ -3110,7 +3112,10 @@ mutual
           (substElem f' (Ext wk3 (CtxVar 2)))
           (substElem f' (Ext wk3 (CtxVar 1)))
           (substTy motTy (Ext wk3 (Class (CtxVar 2))))
-        pure (QuotElim f' q', substTy motTy (Ext Id q'),
+        mirrorHoleDefs
+        stB <- getSt
+        pure (birthQuotE stB.kernelSig ctx a r motTy f' q' (certOr wd),
+              substTy motTy (Ext Id q'),
               Nd [PMotive motTy motSk, PWD (certOr wd)] [fSk, qSk])
       Nothing => throw "\{site}: quot-elim scrutinee has non-quotient type\{structuralHint}"
   inferElem ctx env site SZeroC = pure (Elem.ZeroTy, Ty.UniverseTy, Nd [] [])

--- a/src/idris/Nova/Elaboration.idr
+++ b/src/idris/Nova/Elaboration.idr
@@ -2051,6 +2051,17 @@ assume stmt site comp = do
   fth4 : (a, b, c, d) -> d
   fth4 (_, _, _, x) = x
 
+||| Mirror solved holes into the kernel's Σ — in Σ order (each
+||| solution is prefix-legal, so earlier mirrors carry later ones);
+||| incremental, so safe to call both at item end and at certificate
+||| birth (where it makes solved holes visible to the derivation
+||| assembler). Eager per-flip mirroring is order-fragile: a
+||| solution may mention a hole that is itself solved only later in
+||| the same item. A mirror that still fails (the solution mentions a
+||| dirty-run entry) is skipped — the run is dirty in that case and
+||| the kernel copy is never consulted. Defined with the seat below.
+mirrorHoleDefs : ElabM ()
+
 mutual
   ||| One discharge attempt: engine + eager kernel replay. Right =
   ||| replayed certificate; Left = the site string, annotated when the
@@ -2062,7 +2073,14 @@ mutual
     let cs = mkCandSet st ctx
     let mcert = spEqElemC spDepth st cs ctx a b ty
     case map (\cert => (cert, kCheckEqElem st.sig ctx kernelFuel cert a b ty)) mcert of
-      Just (cert, Right ()) => pure (Right cert)
+      Just (cert, Right ()) => do
+        -- the judgment-carrying pilot: assemble and store the
+        -- equation's derivation at birth where the shape allows —
+        -- solved holes mirrored first, so hole-typed equations can
+        -- type their endpoints
+        mirrorHoleDefs
+        st' <- getSt
+        pure (Right (birthEqDeriv st'.kernelSig ctx cert a b ty))
       Just (_, Left kerrMsg) => pure (Left (site ++ " [replay failed: " ++ kerrMsg ++ "]"))
       Nothing => pure (Left site)
 
@@ -3519,14 +3537,7 @@ constraintCount = do
   st <- getSt
   pure (length (toList st.oblMeta))
 
-||| Mirror solved holes into the kernel's Σ — ONCE, at item end, in
-||| minting order (each solution is prefix-legal, so earlier mirrors
-||| carry later ones). Eager per-flip mirroring is order-fragile: a
-||| solution may mention a hole that is itself solved only later in
-||| the same item. A mirror that still fails (the solution mentions a
-||| dirty-run entry) is skipped — the run is dirty in that case and
-||| the kernel copy is never consulted.
-mirrorHoleDefs : ElabM ()
+-- (declared above attemptE; docstring there)
 mirrorHoleDefs = do
   st <- getSt
   -- Σ ORDER, not minting order: legalize inserts imitation twins

--- a/src/idris/Nova/Elaboration.idr
+++ b/src/idris/Nova/Elaboration.idr
@@ -3037,7 +3037,10 @@ mutual
     case preferPi st ctx fTy of
       Just (a, b, _) => do
         (e', eSk) <- checkElem ctx env site e a
-        pure (PiApp f' e', substTy b (Ext Id e'), Nd [] [fSk, eSk])
+        -- no mirror here: the spine fires per node and the mirror's
+        -- scan would multiply by it; a hole-blocked birth declines
+        stB <- getSt
+        pure (birthPiE stB.kernelSig ctx a b f' e', substTy b (Ext Id e'), Nd [] [fSk, eSk])
       Nothing => throw "\{site}: cannot apply a term of non-Π type\{structuralHint}"
   inferElem ctx env site (SProj1 t) = do
     (t', tTy, tSk) <- inferElem ctx env site t
@@ -3197,7 +3200,8 @@ mutual
       Just (a, b, exp) => do
         recordBinder xr ctx env x a
         (t', tSk) <- checkElem (ctx :< a) (env :< x) site t b
-        pure (PiIntro t', withExpose exp (Nd [] [tSk]))
+        stB <- getSt
+        pure (birthPiI stB.kernelSig ctx a b t', withExpose exp (Nd [] [tSk]))
       Nothing => throw "\{site}: λ checked against a non-Π type\{structuralHint}"
   checkElem ctx env site (SPair u v) ty = do
     st <- getSt

--- a/src/idris/Nova/Elaboration.idr
+++ b/src/idris/Nova/Elaboration.idr
@@ -3046,13 +3046,17 @@ mutual
     (t', tTy, tSk) <- inferElem ctx env site t
     st <- getSt
     case preferSigma st ctx tTy of
-      Just (a, b, _) => pure (SigmaElim1 t', a, Nd [] [tSk])
+      Just (a, b, _) => do
+        stB <- getSt
+        pure (birthProj stB.kernelSig ctx True a b t', a, Nd [] [tSk])
       Nothing => throw "\{site}: cannot project from a term of non-⨯ type\{structuralHint}"
   inferElem ctx env site (SProj2 t) = do
     (t', tTy, tSk) <- inferElem ctx env site t
     st <- getSt
     case preferSigma st ctx tTy of
-      Just (a, b, _) => pure (SigmaElim2 t', substTy b (Ext Id (SigmaElim1 t')), Nd [] [tSk])
+      Just (a, b, _) => do
+        stB <- getSt
+        pure (birthProj stB.kernelSig ctx False a b t', substTy b (Ext Id (SigmaElim1 t')), Nd [] [tSk])
       Nothing => throw "\{site}: cannot project from a term of non-⨯ type\{structuralHint}"
   inferElem ctx env site (SAnn t ty) = do
     (ty', tySk) <- elabTy ctx env site ty
@@ -3068,7 +3072,8 @@ mutual
     recordBinder xr ctx env x eTy
     let hyp = Prf (Elem.EqTy (CtxVar 0) (substElem e' Wk) (substTy eTy Wk))
     (b', bTy, bSk) <- inferElem (ctx :< eTy :< hyp) (env :< x :< wildcard) site b
-    pure (Let e' b', substTy bTy (Ext (Ext Id e') Star), Nd [] [eSk, bSk])
+    stB <- getSt
+    pure (birthLet stB.kernelSig ctx eTy bTy e' b', substTy bTy (Ext (Ext Id e') Star), Nd [] [eSk, bSk])
   inferElem ctx env site (SNatElim (n, nr) mot z (n2, n2r) (ih, ihr) s t) = do
     recordBinder nr ctx env n Ty.NatTy
     (motTy, motSk) <- elabTy (ctx :< Ty.NatTy) (env :< n) site mot
@@ -3209,7 +3214,8 @@ mutual
       Just (a, b, exp) => do
         (u', uSk) <- checkElem ctx env site u a
         (v', vSk) <- checkElem ctx env site v (substTy b (Ext Id u'))
-        pure (SigmaIntro u' v', withExpose exp (Nd [] [uSk, vSk]))
+        stB <- getSt
+        pure (birthSigmaI stB.kernelSig ctx a b u' v', withExpose exp (Nd [] [uSk, vSk]))
       Nothing => throw "\{site}: pair checked against a non-⨯ type\{structuralHint}"
   checkElem ctx env site (SInj1 a) ty = do
     st <- getSt

--- a/src/idris/Nova/Elaboration.idr
+++ b/src/idris/Nova/Elaboration.idr
@@ -3070,7 +3070,11 @@ mutual
     (s', sSk) <- checkElem (ctx :< Ty.NatTy :< motTy) (env :< n2 :< ih) site s
                    (substTy motTy (Chain (Ext Wk (NatIntro1 (CtxVar 0))) Wk))
     (t', tSk) <- checkElem ctx env site t Ty.NatTy
-    pure (NatElim z' s' t', substTy motTy (Ext Id t'),
+    -- the judgment-carrying pilot: the motive is in hand HERE and
+    -- nowhere later — birth the eliminator's typing derivation
+    mirrorHoleDefs
+    stB <- getSt
+    pure (birthNatE stB.kernelSig ctx motTy z' s' t', substTy motTy (Ext Id t'),
           Nd [PMotive motTy motSk] [zSk, sSk, tSk])
   inferElem ctx env site (SSumElim (zn, zr) mot (an, ar) l (bn, br) r t) = do
     (t', tTy, tSk) <- inferElem ctx env site t

--- a/src/idris/Nova/Elaboration.idr
+++ b/src/idris/Nova/Elaboration.idr
@@ -3616,20 +3616,29 @@ mutual
         (e, sk) <- checkElem ctx env site t ty
         pure (e, sk, Nothing)
    where
-    -- the ported switch: the judgment survives only when the
-    -- inferred type IS the expected spelling (a conversion coercion
-    -- is a later route — it needs the equation as a derivation)
+    -- the ported switch. Identical spellings pass the judgment
+    -- through; different ones coerce along nf-eq of the TWO
+    -- FORMATIONS IN HAND (the inferred side's by presupposition,
+    -- the expected side's threaded in) — an optimistic node that
+    -- concludes whenever the types are nf-equal AT CONSUMPTION,
+    -- which is post-hole-solving. A conversion true only by a
+    -- rewrite lemma stays unported (the refiner's seed).
     switchJ : ElabM (Elem, Skel, Maybe Jud)
     switchJ = do
       (t', inferred, tSk, mtJ) <- inferElemJ ctx jctx env site t
       c <- convTy ctx env "\{site}: inferred vs expected type" Nothing inferred ty
       let mJ = the (Maybe Jud) $ do
                  tJ <- mtJ
-                 let True = inferred == ty
+                 let True = tJ.ty == inferred
                    | _ => Nothing
-                 let True = tJ.ty == ty
-                   | _ => Nothing
-                 Just tJ
+                 if inferred == ty
+                   then Just tJ
+                   else do
+                     ft <- mFT
+                     let True = ft.ty == ty
+                       | _ => Nothing
+                     Just (judCoe (MkJudTyEq (DNfEqTy (DPresupElTy tJ.deriv) ft.deriv)
+                                     ctx inferred ty) tJ)
       pure (t', addPayload (PSwitch (certOr c)) tSk, mJ)
 
   ||| The formation side of the port: a ported type route CONSTRUCTS

--- a/src/idris/Nova/Elaboration.idr
+++ b/src/idris/Nova/Elaboration.idr
@@ -3471,29 +3471,31 @@ mutual
   ||| erasures agreeing with the erased flow's spellings — a ported
   ||| judgment never changes what elaboration produces, only what it
   ||| KNOWS. Exposure sites (a Π reached through the rewrite
-  ||| normalizer) are not ported yet and drop the judgment.
+  ||| normalizer) are not ported yet and drop the judgment. `jctx`
+  ||| carries each binder's formation where the pushing route had it
+  ||| — the intrinsic context, arriving strangler-fig.
   export
-  inferElemJ : Ctx -> NameEnv -> String -> SElem -> ElabM (Elem, Ty, Skel, Maybe Jud)
-  inferElemJ ctx env site s@(SVar _ _ i) = do
+  inferElemJ : Ctx -> JCtx -> NameEnv -> String -> SElem -> ElabM (Elem, Ty, Skel, Maybe Jud)
+  inferElemJ ctx jctx env site s@(SVar _ _ i) = do
     (e, ty, sk) <- inferElem ctx env site s
     pure (e, ty, sk, judVar ctx i)
-  inferElemJ ctx env site s@(SSig _ _) = do
+  inferElemJ ctx jctx env site s@(SSig _ _) = do
     (e, ty, sk) <- inferElem ctx env site s
     let mJ = the (Maybe Jud) $ case e of
                SigVar x [<] => Just (judSig0 x ty ctx)
                _ => Nothing
     pure (e, ty, sk, mJ)
-  inferElemJ ctx env site SZeroN = do
+  inferElemJ ctx jctx env site SZeroN = do
     (e, ty, sk) <- inferElem ctx env site SZeroN
     pure (e, ty, sk, Just (judZero ctx))
-  inferElemJ ctx env site SUnitI = do
+  inferElemJ ctx jctx env site SUnitI = do
     (e, ty, sk) <- inferElem ctx env site SUnitI
     pure (e, ty, sk, Just (judOneI ctx))
-  inferElemJ ctx env site (SSuc t) = do
-    (t', tSk, mtJ) <- checkElemJ ctx env site t Ty.NatTy (Just (judTyNat ctx))
+  inferElemJ ctx jctx env site (SSuc t) = do
+    (t', tSk, mtJ) <- checkElemJ ctx jctx env site t Ty.NatTy (Just (judTyNat ctx))
     pure (NatIntro1 t', Ty.NatTy, Nd [] [tSk], judSuc <$> mtJ)
-  inferElemJ ctx env site (SApp f e) = do
-    (f', fTy, fSk, mfJ) <- inferElemJ ctx env site f
+  inferElemJ ctx jctx env site (SApp f e) = do
+    (f', fTy, fSk, mfJ) <- inferElemJ ctx jctx env site f
     st <- getSt
     case preferPi st ctx fTy of
       Just (a, b, exp) => do
@@ -3504,7 +3506,7 @@ mutual
                       let True = fJ.ty == Ty.PiTy a b
                         | _ => Nothing
                       Just fJ
-        (e', eSk, meJ) <- checkElemJ ctx env site e a
+        (e', eSk, meJ) <- checkElemJ ctx jctx env site e a
                             ((\fJ => judInvPiDom fJ a) <$> mfJok)
         stB <- getSt
         let mJ = the (Maybe Jud) $ do
@@ -3519,25 +3521,26 @@ mutual
                     Nothing => birthPiE stB.kernelSig ctx a b f' e'
         pure (app, substTy b (Ext Id e'), Nd [] [fSk, eSk], mJ)
       Nothing => throw "\{site}: cannot apply a term of non-Π type\{structuralHint}"
-  inferElemJ ctx env site (SNatElim (n, nr) mot z (n2, n2r) (ih, ihr) s t) = do
+  inferElemJ ctx jctx env site (SNatElim (n, nr) mot z (n2, n2r) (ih, ihr) s t) = do
     recordBinder nr ctx env n Ty.NatTy
-    (motTy, motSk, mMotJT0) <- elabTyJ (ctx :< Ty.NatTy) (env :< n) site mot
+    (motTy, motSk, mMotJT0) <- elabTyJ (ctx :< Ty.NatTy) (jctx :< Just DTyNat) (env :< n) site mot
     stM <- getSt
     let mMotJT = mMotJT0
                  <|> (the (Maybe JudTy) $ do
                         d <- judStoredTy stM.kernelSig (ctx :< Ty.NatTy) motTy
                         Just (MkJudTy d (ctx :< Ty.NatTy) motTy))
     let zTy = substTy motTy (Ext Id NatIntro0)
-    (z', zSk, mzJ) <- checkElemJ ctx env site z zTy
+    (z', zSk, mzJ) <- checkElemJ ctx jctx env site z zTy
                         ((\mj => judSubTy (DSubExt DSubId DTyNat DElNatZ) ctx zTy mj) <$> mMotJT)
     recordBinder n2r ctx env n2 Ty.NatTy
     recordBinder ihr (ctx :< Ty.NatTy) (env :< n2) ih motTy
     let sctx = ctx :< Ty.NatTy :< motTy
+    let sjctx = jctx :< Just DTyNat :< ((.deriv) <$> mMotJT)
     let sTy = substTy motTy (Chain (Ext Wk (NatIntro1 (CtxVar 0))) Wk)
     let sSub = DSubComp DSubWk (DSubExt DSubWk DTyNat (DElNatS (DElVar 0)))
-    (s', sSk, msJ) <- checkElemJ sctx (env :< n2 :< ih) site s sTy
+    (s', sSk, msJ) <- checkElemJ sctx sjctx (env :< n2 :< ih) site s sTy
                         ((\mj => judSubTy sSub sctx sTy mj) <$> mMotJT)
-    (t', tSk, mtJ) <- checkElemJ ctx env site t Ty.NatTy (Just (judTyNat ctx))
+    (t', tSk, mtJ) <- checkElemJ ctx jctx env site t Ty.NatTy (Just (judTyNat ctx))
     mirrorHoleDefs
     stB <- getSt
     let mJ = the (Maybe Jud) $ do
@@ -3553,7 +3556,7 @@ mutual
                  | _ => Nothing
                Just (judNatE motJT zJ sJ tJ)
     let mJ = if reconDebug
-               then trace "jud: natE mot=\{show (isJust mMotJT)} z=\{show (isJust mzJ)} s=\{show (isJust msJ)} t=\{show (isJust mtJ)} whole=\{show (isJust mJ)} MOT=\{show motTy}" mJ
+               then trace "jud: natE mot=\{show (isJust mMotJT)} z=\{show (isJust mzJ)} s=\{show (isJust msJ)} t=\{show (isJust mtJ)} whole=\{show (isJust mJ)}" mJ
                else mJ
     let elimE = case mJ of
                   Just j => storeJudEl ctx (NatElim z' s' t') (substTy motTy (Ext Id t'))
@@ -3561,17 +3564,17 @@ mutual
                   Nothing => birthNatE stB.kernelSig ctx motTy z' s' t'
     pure (elimE, substTy motTy (Ext Id t'),
           Nd [PMotive motTy motSk] [zSk, sSk, tSk], mJ)
-  inferElemJ ctx env site s = do
+  inferElemJ ctx jctx env site s = do
     (e, ty, sk) <- inferElem ctx env site s
     pure (e, ty, sk, Nothing)
 
   ||| The checking side of the port; `mFT` is the EXPECTED TYPE's
   ||| formation where the caller holds one (an application's domain
-  ||| by inversion, a def item's type by its stored birth) — the λ
-  ||| route needs it for el-pi-i's domain premise.
+  ||| by inversion, a def item's type by its own construction) — the
+  ||| λ route needs it for el-pi-i's domain premise.
   export
-  checkElemJ : Ctx -> NameEnv -> String -> SElem -> Ty -> Maybe JudTy -> ElabM (Elem, Skel, Maybe Jud)
-  checkElemJ ctx env site (SLam (x, xr) t) ty mFT = do
+  checkElemJ : Ctx -> JCtx -> NameEnv -> String -> SElem -> Ty -> Maybe JudTy -> ElabM (Elem, Skel, Maybe Jud)
+  checkElemJ ctx jctx env site (SLam (x, xr) t) ty mFT = do
     st <- getSt
     case preferPi st ctx ty of
       Just (a, b, exp) => do
@@ -3583,7 +3586,9 @@ mutual
                       let True = ft.ty == ty
                         | _ => Nothing
                       Just ft
-        (t', tSk, mtJ) <- checkElemJ (ctx :< a) (env :< x) site t b
+        (t', tSk, mtJ) <- checkElemJ (ctx :< a)
+                            (jctx :< ((\ft => DInvPiDom ft.deriv) <$> mFTok))
+                            (env :< x) site t b
                             ((\ft => MkJudTy (DInvPiCod ft.deriv) (ctx :< a) b) <$> mFTok)
         stB <- getSt
         let mJ = the (Maybe Jud) $ do
@@ -3598,7 +3603,7 @@ mutual
                     Nothing => birthPiI stB.kernelSig ctx a b t'
         pure (lam, withExpose exp (Nd [] [tSk]), mJ)
       Nothing => throw "\{site}: λ checked against a non-Π type\{structuralHint}"
-  checkElemJ ctx env site t ty mFT =
+  checkElemJ ctx jctx env site t ty mFT =
     case t of
       SVar _ _ _ => switchJ
       SSig _ _ => switchJ
@@ -3616,7 +3621,7 @@ mutual
     -- is a later route — it needs the equation as a derivation)
     switchJ : ElabM (Elem, Skel, Maybe Jud)
     switchJ = do
-      (t', inferred, tSk, mtJ) <- inferElemJ ctx env site t
+      (t', inferred, tSk, mtJ) <- inferElemJ ctx jctx env site t
       c <- convTy ctx env "\{site}: inferred vs expected type" Nothing inferred ty
       let mJ = the (Maybe Jud) $ do
                  tJ <- mtJ
@@ -3633,10 +3638,10 @@ mutual
   ||| pre-mirror hole references are fine here, the judgment is
   ||| untrusted and validated at consumption).
   export
-  elabTyJ : Ctx -> NameEnv -> String -> STy -> ElabM (Ty, Skel, Maybe JudTy)
-  elabTyJ ctx env site (STyPi x a b) = do
-    (a', aSk, maJ) <- elabTyJ ctx env site a
-    (b', bSk, mbJ) <- elabTyJ (ctx :< a') (env :< x) site b
+  elabTyJ : Ctx -> JCtx -> NameEnv -> String -> STy -> ElabM (Ty, Skel, Maybe JudTy)
+  elabTyJ ctx jctx env site (STyPi x a b) = do
+    (a', aSk, maJ) <- elabTyJ ctx jctx env site a
+    (b', bSk, mbJ) <- elabTyJ (ctx :< a') (jctx :< ((.deriv) <$> maJ)) (env :< x) site b
     stB <- getSt
     let mJT = the (Maybe JudTy) $ do
                 aJ <- maJ
@@ -3646,9 +3651,9 @@ mutual
                 Just _ => Ty.PiTy a' b'
                 Nothing => birthTy stB.kernelSig ctx (Ty.PiTy a' b')
     pure (piT, Nd [] [aSk, bSk], mJT)
-  elabTyJ ctx env site (STySigma x a b) = do
-    (a', aSk, maJ) <- elabTyJ ctx env site a
-    (b', bSk, mbJ) <- elabTyJ (ctx :< a') (env :< x) site b
+  elabTyJ ctx jctx env site (STySigma x a b) = do
+    (a', aSk, maJ) <- elabTyJ ctx jctx env site a
+    (b', bSk, mbJ) <- elabTyJ (ctx :< a') (jctx :< ((.deriv) <$> maJ)) (env :< x) site b
     stB <- getSt
     let mJT = the (Maybe JudTy) $ do
                 aJ <- maJ
@@ -3658,10 +3663,10 @@ mutual
                 Just _ => Ty.SigmaTy a' b'
                 Nothing => birthTy stB.kernelSig ctx (Ty.SigmaTy a' b')
     pure (sgT, Nd [] [aSk, bSk], mJT)
-  elabTyJ ctx env site (STyEq l r t) = do
-    (t', tSk, mtJT) <- elabTyJ ctx env site t
-    (l', lSk, mlJ) <- checkElemJ ctx env site l t' mtJT
-    (r', rSk, mrJ) <- checkElemJ ctx env site r t' mtJT
+  elabTyJ ctx jctx env site (STyEq l r t) = do
+    (t', tSk, mtJT) <- elabTyJ ctx jctx env site t
+    (l', lSk, mlJ) <- checkElemJ ctx jctx env site l t' mtJT
+    (r', rSk, mrJ) <- checkElemJ ctx jctx env site r t' mtJT
     let mJT = the (Maybe JudTy) $ do
                 tJT <- mtJT
                 lJ <- mlJ
@@ -3672,8 +3677,8 @@ mutual
                   | _ => Nothing
                 Just (judTyPrf (judCodeEq tJT lJ rJ))
     pure (Prf (Elem.EqTy l' r' t'), Nd [] [Nd [] [lSk, rSk, tSk]], mJT)
-  elabTyJ ctx env site (STyEl e) = do
-    (e', eSk, meJ) <- checkElemJ ctx env site e Ty.UniverseTy (judTyPrim ctx Ty.UniverseTy)
+  elabTyJ ctx jctx env site (STyEl e) = do
+    (e', eSk, meJ) <- checkElemJ ctx jctx env site e Ty.UniverseTy (judTyPrim ctx Ty.UniverseTy)
     stB <- getSt
     let mJT = the (Maybe JudTy) $ do
                 eJ <- meJ
@@ -3684,8 +3689,8 @@ mutual
                 Just j => storeJudTy ctx (El e') j.deriv (El e')
                 Nothing => birthTy stB.kernelSig ctx (El e')
     pure (elT, Nd [] [eSk], mJT)
-  elabTyJ ctx env site (STyPrf e) = do
-    (e', eSk, meJ) <- checkElemJ ctx env site e Ty.PropTy (judTyPrim ctx Ty.PropTy)
+  elabTyJ ctx jctx env site (STyPrf e) = do
+    (e', eSk, meJ) <- checkElemJ ctx jctx env site e Ty.PropTy (judTyPrim ctx Ty.PropTy)
     stB <- getSt
     let mJT = the (Maybe JudTy) $ do
                 eJ <- meJ
@@ -3696,9 +3701,20 @@ mutual
                 Just j => storeJudTy ctx (Prf e') j.deriv (Prf e')
                 Nothing => birthTy stB.kernelSig ctx (Prf e')
     pure (prT, Nd [] [eSk], mJT)
-  elabTyJ ctx env site t = do
+  elabTyJ ctx jctx env site t = do
     (t', sk) <- elabTy ctx env site t
-    pure (t', sk, judTyPrim ctx t')
+    let mJT = judTyPrim ctx t'
+              <|> (the (Maybe JudTy) $ case t' of
+                     -- a type HOLE at its own context, or a closed
+                     -- signature type: ty-sig with the sub-norm
+                     -- premises read off the judgment context
+                     Ty.SigVar q [<] => judTySigVars q [<] 0 t' ctx
+                     Ty.SigVar q es =>
+                       if es == idSpine (length ctx)
+                         then judTySigVars q jctx 0 t' ctx
+                         else Nothing
+                     _ => Nothing)
+    pure (t', sk, mJT)
 
 -- ===== Items =====
 
@@ -4105,14 +4121,14 @@ elabItemGo (SDef x ty body) = do
   -- item's type, references are bare names
   -- the port's entry: type and body elaborate through the
   -- judgment-carrying spine
-  (ty', tySk, mFT0) <- elabTyJ [<] [<] "def \{x}" ty
+  (ty', tySk, mFT0) <- elabTyJ [<] [<] [<] "def \{x}" ty
   stFT <- getSt
   let mFT = mFT0
             <|> ((\d => MkJudTy d [<] ty') <$> judStoredTy stFT.kernelSig [<] ty')
   let mFT = if reconDebug
               then trace "jud: def \{x} formation \{show (isJust mFT)}" mFT
               else mFT
-  (body', bodySk, _) <- checkElemJ [<] [<] "def \{x}" body ty' mFT
+  (body', bodySk, _) <- checkElemJ [<] [<] [<] "def \{x}" body ty' mFT
   -- clean means the RUN is clean: an earlier item's assumption poisons
   -- everything after it (the kernel Σ cannot contain the earlier item,
   -- so references to it are unresolvable anyway)

--- a/src/idris/Nova/Elaboration.idr
+++ b/src/idris/Nova/Elaboration.idr
@@ -50,6 +50,9 @@ import Nova.Kernel.Reconstruct
 
 import Me.Russoul.Text.Position
 import Me.Russoul.Text.Range
+import Debug.Trace
+
+import Nova.Elaboration.Jud
 import Nova.Elaboration.Named
 import Nova.Elaboration.Surface
 import Nova.Elaboration.Clauses
@@ -3456,6 +3459,247 @@ mutual
     c <- convTy ctx env "\{site}: inferred vs expected type" Nothing inferred ty
     pure (t', addPayload (PSwitch (certOr c)) tSk)
 
+  ||| THE PORT (docs/NovaPipeline.txt, phase 3 end-state): the
+  ||| judgment-carrying elaboration spine, route by route. A ported
+  ||| route CONSTRUCTS its judgment from its sub-judgments — premises
+  ||| in hand, one node per rule, no reconstruction — and stores the
+  ||| derivation for the emission pass to serve; an unported route
+  ||| delegates the whole subtree to the erased elaborator and
+  ||| returns no judgment (the emission pass remains its adapter).
+  ||| Erasures are identical to the erased routes'; the judgment is
+  ||| strictly additional. Every composition is GATED on the cached
+  ||| erasures agreeing with the erased flow's spellings — a ported
+  ||| judgment never changes what elaboration produces, only what it
+  ||| KNOWS. Exposure sites (a Π reached through the rewrite
+  ||| normalizer) are not ported yet and drop the judgment.
+  export
+  inferElemJ : Ctx -> NameEnv -> String -> SElem -> ElabM (Elem, Ty, Skel, Maybe Jud)
+  inferElemJ ctx env site s@(SVar _ _ i) = do
+    (e, ty, sk) <- inferElem ctx env site s
+    pure (e, ty, sk, judVar ctx i)
+  inferElemJ ctx env site s@(SSig _ _) = do
+    (e, ty, sk) <- inferElem ctx env site s
+    let mJ = the (Maybe Jud) $ case e of
+               SigVar x [<] => Just (judSig0 x ty ctx)
+               _ => Nothing
+    pure (e, ty, sk, mJ)
+  inferElemJ ctx env site SZeroN = do
+    (e, ty, sk) <- inferElem ctx env site SZeroN
+    pure (e, ty, sk, Just (judZero ctx))
+  inferElemJ ctx env site SUnitI = do
+    (e, ty, sk) <- inferElem ctx env site SUnitI
+    pure (e, ty, sk, Just (judOneI ctx))
+  inferElemJ ctx env site (SSuc t) = do
+    (t', tSk, mtJ) <- checkElemJ ctx env site t Ty.NatTy (Just (judTyNat ctx))
+    pure (NatIntro1 t', Ty.NatTy, Nd [] [tSk], judSuc <$> mtJ)
+  inferElemJ ctx env site (SApp f e) = do
+    (f', fTy, fSk, mfJ) <- inferElemJ ctx env site f
+    st <- getSt
+    case preferPi st ctx fTy of
+      Just (a, b, exp) => do
+        let mfJok = the (Maybe Jud) $ do
+                      fJ <- mfJ
+                      let Nothing = exp
+                        | _ => Nothing
+                      let True = fJ.ty == Ty.PiTy a b
+                        | _ => Nothing
+                      Just fJ
+        (e', eSk, meJ) <- checkElemJ ctx env site e a
+                            ((\fJ => judInvPiDom fJ a) <$> mfJok)
+        stB <- getSt
+        let mJ = the (Maybe Jud) $ do
+                   fJ <- mfJok
+                   eJ <- meJ
+                   let True = eJ.ty == a
+                     | _ => Nothing
+                   judPiE fJ eJ (judInvPiCod fJ a b)
+        let app = case mJ of
+                    Just j => storeJudEl ctx (PiApp f' e') (substTy b (Ext Id e'))
+                                j.deriv (PiApp f' e')
+                    Nothing => birthPiE stB.kernelSig ctx a b f' e'
+        pure (app, substTy b (Ext Id e'), Nd [] [fSk, eSk], mJ)
+      Nothing => throw "\{site}: cannot apply a term of non-Π type\{structuralHint}"
+  inferElemJ ctx env site (SNatElim (n, nr) mot z (n2, n2r) (ih, ihr) s t) = do
+    recordBinder nr ctx env n Ty.NatTy
+    (motTy, motSk, mMotJT0) <- elabTyJ (ctx :< Ty.NatTy) (env :< n) site mot
+    stM <- getSt
+    let mMotJT = mMotJT0
+                 <|> (the (Maybe JudTy) $ do
+                        d <- judStoredTy stM.kernelSig (ctx :< Ty.NatTy) motTy
+                        Just (MkJudTy d (ctx :< Ty.NatTy) motTy))
+    let zTy = substTy motTy (Ext Id NatIntro0)
+    (z', zSk, mzJ) <- checkElemJ ctx env site z zTy
+                        ((\mj => judSubTy (DSubExt DSubId DTyNat DElNatZ) ctx zTy mj) <$> mMotJT)
+    recordBinder n2r ctx env n2 Ty.NatTy
+    recordBinder ihr (ctx :< Ty.NatTy) (env :< n2) ih motTy
+    let sctx = ctx :< Ty.NatTy :< motTy
+    let sTy = substTy motTy (Chain (Ext Wk (NatIntro1 (CtxVar 0))) Wk)
+    let sSub = DSubComp DSubWk (DSubExt DSubWk DTyNat (DElNatS (DElVar 0)))
+    (s', sSk, msJ) <- checkElemJ sctx (env :< n2 :< ih) site s sTy
+                        ((\mj => judSubTy sSub sctx sTy mj) <$> mMotJT)
+    (t', tSk, mtJ) <- checkElemJ ctx env site t Ty.NatTy (Just (judTyNat ctx))
+    mirrorHoleDefs
+    stB <- getSt
+    let mJ = the (Maybe Jud) $ do
+               motJT <- mMotJT
+               zJ <- mzJ
+               sJ <- msJ
+               tJ <- mtJ
+               let True = zJ.ty == zTy
+                 | _ => Nothing
+               let True = sJ.ty == sTy
+                 | _ => Nothing
+               let True = tJ.ty == Ty.NatTy
+                 | _ => Nothing
+               Just (judNatE motJT zJ sJ tJ)
+    let mJ = if reconDebug
+               then trace "jud: natE mot=\{show (isJust mMotJT)} z=\{show (isJust mzJ)} s=\{show (isJust msJ)} t=\{show (isJust mtJ)} whole=\{show (isJust mJ)} MOT=\{show motTy}" mJ
+               else mJ
+    let elimE = case mJ of
+                  Just j => storeJudEl ctx (NatElim z' s' t') (substTy motTy (Ext Id t'))
+                              j.deriv (NatElim z' s' t')
+                  Nothing => birthNatE stB.kernelSig ctx motTy z' s' t'
+    pure (elimE, substTy motTy (Ext Id t'),
+          Nd [PMotive motTy motSk] [zSk, sSk, tSk], mJ)
+  inferElemJ ctx env site s = do
+    (e, ty, sk) <- inferElem ctx env site s
+    pure (e, ty, sk, Nothing)
+
+  ||| The checking side of the port; `mFT` is the EXPECTED TYPE's
+  ||| formation where the caller holds one (an application's domain
+  ||| by inversion, a def item's type by its stored birth) — the λ
+  ||| route needs it for el-pi-i's domain premise.
+  export
+  checkElemJ : Ctx -> NameEnv -> String -> SElem -> Ty -> Maybe JudTy -> ElabM (Elem, Skel, Maybe Jud)
+  checkElemJ ctx env site (SLam (x, xr) t) ty mFT = do
+    st <- getSt
+    case preferPi st ctx ty of
+      Just (a, b, exp) => do
+        recordBinder xr ctx env x a
+        let mFTok = the (Maybe JudTy) $ do
+                      ft <- mFT
+                      let Nothing = exp
+                        | _ => Nothing
+                      let True = ft.ty == ty
+                        | _ => Nothing
+                      Just ft
+        (t', tSk, mtJ) <- checkElemJ (ctx :< a) (env :< x) site t b
+                            ((\ft => MkJudTy (DInvPiCod ft.deriv) (ctx :< a) b) <$> mFTok)
+        stB <- getSt
+        let mJ = the (Maybe Jud) $ do
+                   ft <- mFTok
+                   tJ <- mtJ
+                   let True = tJ.ty == b
+                     | _ => Nothing
+                   Just (judPiI (MkJudTy (DInvPiDom ft.deriv) ctx a) tJ)
+        let lam = case mJ of
+                    Just j => storeJudEl ctx (PiIntro t') (Ty.PiTy a b)
+                                j.deriv (PiIntro t')
+                    Nothing => birthPiI stB.kernelSig ctx a b t'
+        pure (lam, withExpose exp (Nd [] [tSk]), mJ)
+      Nothing => throw "\{site}: λ checked against a non-Π type\{structuralHint}"
+  checkElemJ ctx env site t ty mFT =
+    case t of
+      SVar _ _ _ => switchJ
+      SSig _ _ => switchJ
+      SZeroN => switchJ
+      SUnitI => switchJ
+      SSuc _ => switchJ
+      SApp _ _ => switchJ
+      SNatElim _ _ _ _ _ _ _ => switchJ
+      _ => do
+        (e, sk) <- checkElem ctx env site t ty
+        pure (e, sk, Nothing)
+   where
+    -- the ported switch: the judgment survives only when the
+    -- inferred type IS the expected spelling (a conversion coercion
+    -- is a later route — it needs the equation as a derivation)
+    switchJ : ElabM (Elem, Skel, Maybe Jud)
+    switchJ = do
+      (t', inferred, tSk, mtJ) <- inferElemJ ctx env site t
+      c <- convTy ctx env "\{site}: inferred vs expected type" Nothing inferred ty
+      let mJ = the (Maybe Jud) $ do
+                 tJ <- mtJ
+                 let True = inferred == ty
+                   | _ => Nothing
+                 let True = tJ.ty == ty
+                   | _ => Nothing
+                 Just tJ
+      pure (t', addPayload (PSwitch (certOr c)) tSk, mJ)
+
+  ||| The formation side of the port: a ported type route CONSTRUCTS
+  ||| its formation from sub-judgments (the eliminator motives this
+  ||| feeds are precisely where reconstruction kept failing —
+  ||| pre-mirror hole references are fine here, the judgment is
+  ||| untrusted and validated at consumption).
+  export
+  elabTyJ : Ctx -> NameEnv -> String -> STy -> ElabM (Ty, Skel, Maybe JudTy)
+  elabTyJ ctx env site (STyPi x a b) = do
+    (a', aSk, maJ) <- elabTyJ ctx env site a
+    (b', bSk, mbJ) <- elabTyJ (ctx :< a') (env :< x) site b
+    stB <- getSt
+    let mJT = the (Maybe JudTy) $ do
+                aJ <- maJ
+                bJ <- mbJ
+                Just (judTyPi aJ bJ)
+    let piT = case mJT of
+                Just _ => Ty.PiTy a' b'
+                Nothing => birthTy stB.kernelSig ctx (Ty.PiTy a' b')
+    pure (piT, Nd [] [aSk, bSk], mJT)
+  elabTyJ ctx env site (STySigma x a b) = do
+    (a', aSk, maJ) <- elabTyJ ctx env site a
+    (b', bSk, mbJ) <- elabTyJ (ctx :< a') (env :< x) site b
+    stB <- getSt
+    let mJT = the (Maybe JudTy) $ do
+                aJ <- maJ
+                bJ <- mbJ
+                Just (judTySigma aJ bJ)
+    let sgT = case mJT of
+                Just _ => Ty.SigmaTy a' b'
+                Nothing => birthTy stB.kernelSig ctx (Ty.SigmaTy a' b')
+    pure (sgT, Nd [] [aSk, bSk], mJT)
+  elabTyJ ctx env site (STyEq l r t) = do
+    (t', tSk, mtJT) <- elabTyJ ctx env site t
+    (l', lSk, mlJ) <- checkElemJ ctx env site l t' mtJT
+    (r', rSk, mrJ) <- checkElemJ ctx env site r t' mtJT
+    let mJT = the (Maybe JudTy) $ do
+                tJT <- mtJT
+                lJ <- mlJ
+                rJ <- mrJ
+                let True = lJ.ty == t'
+                  | _ => Nothing
+                let True = rJ.ty == t'
+                  | _ => Nothing
+                Just (judTyPrf (judCodeEq tJT lJ rJ))
+    pure (Prf (Elem.EqTy l' r' t'), Nd [] [Nd [] [lSk, rSk, tSk]], mJT)
+  elabTyJ ctx env site (STyEl e) = do
+    (e', eSk, meJ) <- checkElemJ ctx env site e Ty.UniverseTy (judTyPrim ctx Ty.UniverseTy)
+    stB <- getSt
+    let mJT = the (Maybe JudTy) $ do
+                eJ <- meJ
+                let True = eJ.ty == Ty.UniverseTy
+                  | _ => Nothing
+                Just (judTyEl eJ)
+    let elT = case mJT of
+                Just j => storeJudTy ctx (El e') j.deriv (El e')
+                Nothing => birthTy stB.kernelSig ctx (El e')
+    pure (elT, Nd [] [eSk], mJT)
+  elabTyJ ctx env site (STyPrf e) = do
+    (e', eSk, meJ) <- checkElemJ ctx env site e Ty.PropTy (judTyPrim ctx Ty.PropTy)
+    stB <- getSt
+    let mJT = the (Maybe JudTy) $ do
+                eJ <- meJ
+                let True = eJ.ty == Ty.PropTy
+                  | _ => Nothing
+                Just (judTyPrf eJ)
+    let prT = case mJT of
+                Just j => storeJudTy ctx (Prf e') j.deriv (Prf e')
+                Nothing => birthTy stB.kernelSig ctx (Prf e')
+    pure (prT, Nd [] [eSk], mJT)
+  elabTyJ ctx env site t = do
+    (t', sk) <- elabTy ctx env site t
+    pure (t', sk, judTyPrim ctx t')
+
 -- ===== Items =====
 
 ||| Register a just-accepted definition's equation (if its type peels to
@@ -3859,8 +4103,16 @@ elabItemGo (SDef x ty body) = do
     Nothing => pure ()
   -- items live in the EMPTY context: parameters are Π-binders in the
   -- item's type, references are bare names
-  (ty', tySk) <- elabTy [<] [<] "def \{x}" ty
-  (body', bodySk) <- checkElem [<] [<] "def \{x}" body ty'
+  -- the port's entry: type and body elaborate through the
+  -- judgment-carrying spine
+  (ty', tySk, mFT0) <- elabTyJ [<] [<] "def \{x}" ty
+  stFT <- getSt
+  let mFT = mFT0
+            <|> ((\d => MkJudTy d [<] ty') <$> judStoredTy stFT.kernelSig [<] ty')
+  let mFT = if reconDebug
+              then trace "jud: def \{x} formation \{show (isJust mFT)}" mFT
+              else mFT
+  (body', bodySk, _) <- checkElemJ [<] [<] "def \{x}" body ty' mFT
   -- clean means the RUN is clean: an earlier item's assumption poisons
   -- everything after it (the kernel Σ cannot contain the earlier item,
   -- so references to it are unresolvable anyway)

--- a/src/idris/Nova/Elaboration.idr
+++ b/src/idris/Nova/Elaboration.idr
@@ -162,8 +162,13 @@ record ElabSt where
   ||| an accepted item the reconstructor cannot cover becomes an
   ||| error instead of a silent fallback
   strictDeriv : Bool
+  ||| fingerprint (solved holes, |kernel Σ|) at the last mirror WALK:
+  ||| unchanged means the walk (whose runs are deterministic in these
+  ||| by withFreshEmission) has nothing new to see
+  mirroredAt : Nat
+
 initSt : ElabSt
-initSt = MkElabSt [<] [<] [] [] [] [<] [<] [<] [<] "" [<] False
+initSt = MkElabSt [<] [<] [] [] [] [<] [<] [<] [<] "" [<] False 0
 
 ||| Resolve a surface signature reference: aliases first (own module,
 ||| opened imports), else the name itself (qualified references reach
@@ -3557,7 +3562,20 @@ mirrorHoleDefs = do
   let holeNames = map hname (toList st.holeMeta)
   let entries = [ e | e <- toList st.sig
                 , maybe False (`elem` holeNames) (sigEntryName e) ]
-  modifySt $ { kernelSig := go entries st.kernelSig }
+  -- solving REPLACES a declaration with a definition in place, so
+  -- the gate's fingerprint counts solved holes (with |kernel Σ|,
+  -- since a failed mirror retries when a dependency item seats);
+  -- the walk runs under withFreshEmission, making its outcome a
+  -- function of exactly these
+  let solved = length (filter (\e => case e of
+                                       SigDef _ _ _ _ => True
+                                       SigTyDef _ _ _ => True
+                                       _ => False) entries)
+  let fp = S (solved * 1048576 + length (toList st.kernelSig))
+  if fp == st.mirroredAt
+    then pure ()
+    else modifySt $ { kernelSig := withFreshEmission (go entries st.kernelSig)
+                    , mirroredAt := fp }
  where
   go : List SigEntry -> Sig -> Sig
   go [] ks = ks

--- a/src/idris/Nova/Elaboration.idr
+++ b/src/idris/Nova/Elaboration.idr
@@ -51,6 +51,7 @@ import Nova.Kernel.Reconstruct
 import Me.Russoul.Text.Position
 import Me.Russoul.Text.Range
 import Debug.Trace
+import System
 
 import Nova.Elaboration.Jud
 import Nova.Elaboration.Named
@@ -3603,6 +3604,57 @@ mutual
                     Nothing => birthPiI stB.kernelSig ctx a b t'
         pure (lam, withExpose exp (Nd [] [tSk]), mJ)
       Nothing => throw "\{site}: λ checked against a non-Π type\{structuralHint}"
+  checkElemJ ctx jctx env site h@(SHole _ _ _) ty mFT = do
+    -- a hole USE: the reference's judgment is el-sig with the
+    -- sub-norm chain read off the judgment context (fresh holes and
+    -- same-context reuses only; extension reuses carry a weakened
+    -- spine and wait their turn)
+    (e, sk) <- checkElem ctx env site h ty
+    let mJ = the (Maybe Jud) $ case e of
+               SigVar q es =>
+                 if es == idSpine (length ctx)
+                   then judSigVars q jctx 0 e ty ctx
+                   else Nothing
+               _ => Nothing
+    pure (e, sk, mJ)
+  checkElemJ ctx jctx env site (SPair u v) ty mFT = do
+    st <- getSt
+    case preferSigma st ctx ty of
+      Just (a, b, exp) => do
+        let mFTok = the (Maybe JudTy) $ do
+                      ft <- mFT
+                      let Nothing = exp
+                        | _ => Nothing
+                      let True = ft.ty == ty
+                        | _ => Nothing
+                      Just ft
+        (u', uSk, muJ) <- checkElemJ ctx jctx env site u a
+                            ((\ft => MkJudTy (DInvSigmaDom ft.deriv) ctx a) <$> mFTok)
+        let vTy = substTy b (Ext Id u')
+        let mVFT = the (Maybe JudTy) $ do
+                     ft <- mFTok
+                     uJ <- muJ
+                     let True = uJ.ty == a
+                       | _ => Nothing
+                     Just (judSubTy (DSubExt DSubId (DInvSigmaDom ft.deriv) uJ.deriv)
+                             ctx vTy (MkJudTy (DInvSigmaCod ft.deriv) (ctx :< a) b))
+        (v', vSk, mvJ) <- checkElemJ ctx jctx env site v vTy mVFT
+        stB <- getSt
+        let mJ = the (Maybe Jud) $ do
+                   ft <- mFTok
+                   uJ <- muJ
+                   vJ <- mvJ
+                   let True = uJ.ty == a
+                     | _ => Nothing
+                   let True = vJ.ty == vTy
+                     | _ => Nothing
+                   Just (judSigmaI uJ (MkJudTy (DInvSigmaCod ft.deriv) (ctx :< a) b) vJ)
+        let pr = case mJ of
+                   Just j => storeJudEl ctx (SigmaIntro u' v') (Ty.SigmaTy a b)
+                               j.deriv (SigmaIntro u' v')
+                   Nothing => birthSigmaI stB.kernelSig ctx a b u' v'
+        pure (pr, withExpose exp (Nd [] [uSk, vSk]), mJ)
+      Nothing => throw "\{site}: pair checked against a non-⨯ type\{structuralHint}"
   checkElemJ ctx jctx env site t ty mFT =
     case t of
       SVar _ _ _ => switchJ

--- a/src/idris/Nova/Elaboration.idr
+++ b/src/idris/Nova/Elaboration.idr
@@ -3608,13 +3608,18 @@ mirrorHoleDefs = do
                 -- replayed by the derivation kernel; the old
                 -- kernel's verdict only where emission fails (the
                 -- hole-solution residue)
-                if (case emitSol ks delta t dty of
-                      Just ds =>
-                        acceptSolItem ks kernelFuel ds delta dty t == Right ()
-                      Nothing =>
-                        kCheckSolution ks kernelFuel delta t dty == Right ())
-                  then go rest (ks :< e)
-                  else go rest ks
+                case emitSol ks delta t dty of
+                  Just ds =>
+                    if acceptSolItem ks kernelFuel ds delta dty t == Right ()
+                      -- the accepted body's derivation, recorded by
+                      -- name: what a SigVar unfold in the derivation
+                      -- walk substitutes into
+                      then go rest (ks :< recordSigDeriv q (snd (snd ds)) e)
+                      else go rest ks
+                  Nothing =>
+                    if kCheckSolution ks kernelFuel delta t dty == Right ()
+                      then go rest (ks :< e)
+                      else go rest ks
               SigTyDef delta _ t =>
                 if (case emitTySol ks delta t of
                       Just ds =>
@@ -3647,7 +3652,12 @@ seatAccept name residue art entry clean = do
     else case emitDef st.kernelSig art of
       Just ds =>
         case acceptDefItem st.kernelSig kernelFuel ds art.dty art.body of
-          Right () => modifySt $ { kernelSig $= (:< entry) }
+          Right () =>
+            -- record a share-free body derivation where affordable
+            -- (the walk cannot cite DShare bindings); the accepted
+            -- emission is the fallback
+            let dRec = fromMaybe (snd ds) (plainDefDeriv st.kernelSig art) in
+            modifySt $ { kernelSig $= (:< recordSigDeriv art.dname dRec entry) }
           Left err =>
             throw "\{name}: derivation kernel REJECTED the item: \{err}"
       Nothing => do

--- a/src/idris/Nova/Elaboration.idr
+++ b/src/idris/Nova/Elaboration.idr
@@ -2936,21 +2936,25 @@ mutual
   elabTy ctx env site (STyPi x a b) = do
     (a', aSk) <- elabTy ctx env site a
     (b', bSk) <- elabTy (ctx :< a') (env :< x) site b
-    pure (Ty.PiTy a' b', Nd [] [aSk, bSk])
+    stB <- getSt
+    pure (birthTy stB.kernelSig ctx (Ty.PiTy a' b'), Nd [] [aSk, bSk])
   elabTy ctx env site (STySigma x a b) = do
     (a', aSk) <- elabTy ctx env site a
     (b', bSk) <- elabTy (ctx :< a') (env :< x) site b
-    pure (Ty.SigmaTy a' b', Nd [] [aSk, bSk])
+    stB <- getSt
+    pure (birthTy stB.kernelSig ctx (Ty.SigmaTy a' b'), Nd [] [aSk, bSk])
   elabTy ctx env site (STySum a b) = do
     (a', aSk) <- elabTy ctx env site a
     (b', bSk) <- elabTy ctx env site b
-    pure (Ty.SumTy a' b', Nd [] [aSk, bSk])
+    stB <- getSt
+    pure (birthTy stB.kernelSig ctx (Ty.SumTy a' b'), Nd [] [aSk, bSk])
   elabTy ctx env site (STyQuot a (nx, nxr) (ny, nyr) r) = do
     (a', aSk) <- elabTy ctx env site a
     recordBinder nxr ctx env nx a'
     recordBinder nyr (ctx :< a') (env :< nx) ny (substTy a' Wk)
     (r', rSk) <- checkElem (ctx :< a' :< substTy a' Wk) (env :< nx :< ny) site r Ty.PropTy
-    pure (Ty.Quotient a' r', Nd [] [aSk, rSk])
+    stB <- getSt
+    pure (birthTy stB.kernelSig ctx (Ty.Quotient a' r'), Nd [] [aSk, rSk])
   elabTy ctx env site (STyNu f) = do
     -- e-ty-nu
     (f', fSks) <- elabPoly ctx env site f
@@ -2964,11 +2968,13 @@ mutual
     pure (Prf (Elem.EqTy l' r' t'), Nd [] [Nd [] [lSk, rSk, tSk]])
   elabTy ctx env site (STyEl e) = do
     (e', eSk) <- checkElem ctx env site e Ty.UniverseTy
-    pure (El e', Nd [] [eSk])
+    stB <- getSt
+    pure (birthTy stB.kernelSig ctx (El e'), Nd [] [eSk])
   elabTy ctx env site STyProp = pure (Ty.PropTy, Nd [] [])
   elabTy ctx env site (STyPrf e) = do
     (e', eSk) <- checkElem ctx env site e Ty.PropTy
-    pure (Prf e', Nd [] [eSk])
+    stB <- getSt
+    pure (birthTy stB.kernelSig ctx (Prf e'), Nd [] [eSk])
   elabTy ctx env site (STyHole mrng solvable x) = do
     -- a TYPE hole: a type declaration entry at the ambient context
     -- (sig-ty-decl); references are stuck (ty-sig-decl). Solvable

--- a/src/idris/Nova/Elaboration/Jud.idr
+++ b/src/idris/Nova/Elaboration/Jud.idr
@@ -165,6 +165,31 @@ judNatE mot z s t =
   MkJud (DElNatE mot.deriv z.deriv s.deriv t.deriv) t.ctx
     (NatElim z.elem s.elem t.elem) (substTy mot.ty (Ext Id t.elem))
 
+||| The JUDGMENT CONTEXT: alongside the erased context, the
+||| formation derivation of each entry (over its prefix) where the
+||| port had it in hand at the push. The intrinsic context, arriving
+||| strangler-fig: entries pushed by unported routes carry Nothing.
+public export
+JCtx : Type
+JCtx = SnocList (Maybe Deriv)
+
+||| A signature TYPE reference at a spine of plain variables
+||| (ty-sig-var/decl): a hole at its own context (innermost variable
+||| k = 0), or at an extension by k binders. The sub-norm premise
+||| chain is written from the declaration context's entry formations.
+export
+judTySigVars : SigIdentifier -> JCtx -> Nat -> Ty -> Ctx -> Maybe JudTy
+judTySigVars x jdelta k sp cx = do
+  dSub <- go jdelta k
+  pure (MkJudTy (DTySig x dSub) cx sp)
+ where
+  go : JCtx -> Nat -> Maybe Deriv
+  go [<] _ = Just DSubNEmpty
+  go (rest :< mA) d = do
+    dEs <- go rest (S d)
+    dA <- mA
+    pure (DSubNExt dEs dA (DElVar d))
+
 -- ===== type formations by construction =====
 
 export

--- a/src/idris/Nova/Elaboration/Jud.idr
+++ b/src/idris/Nova/Elaboration/Jud.idr
@@ -112,6 +112,98 @@ export
 judCoe : JudTyEq -> Jud -> Jud
 judCoe eq j = MkJud (DElTyCoe eq.deriv j.deriv) j.ctx j.elem eq.rhs
 
+-- ===== introductions and references =====
+
+export
+judZero : Ctx -> Jud
+judZero cx = MkJud DElNatZ cx NatIntro0 Ty.NatTy
+
+export
+judSuc : Jud -> Jud
+judSuc j = MkJud (DElNatS j.deriv) j.ctx (NatIntro1 j.elem) Ty.NatTy
+
+export
+judOneI : Ctx -> Jud
+judOneI cx = MkJud DElOneI cx OneIntro Ty.OneTy
+
+||| A closed signature reference (empty declaration context): el-sig
+||| at the empty spine. The cached type is spelled as conclude spells
+||| it — the closed type substituted along the empty embedding.
+export
+judSig0 : SigIdentifier -> Ty -> Ctx -> Jud
+judSig0 x a cx =
+  MkJud (DElSig x DSubNEmpty) cx (Elem.SigVar x [<]) (substTy a Terminal)
+
+export
+judTyNat : Ctx -> JudTy
+judTyNat cx = MkJudTy DTyNat cx Ty.NatTy
+
+||| The nullary formations, written down directly.
+export
+judTyPrim : Ctx -> Ty -> Maybe JudTy
+judTyPrim cx Ty.NatTy = Just (MkJudTy DTyNat cx Ty.NatTy)
+judTyPrim cx Ty.OneTy = Just (MkJudTy DTyOne cx Ty.OneTy)
+judTyPrim cx Ty.ZeroTy = Just (MkJudTy DTyZero cx Ty.ZeroTy)
+judTyPrim cx Ty.UniverseTy = Just (MkJudTy DTyUniv cx Ty.UniverseTy)
+judTyPrim cx Ty.PropTy = Just (MkJudTy DTyProp cx Ty.PropTy)
+judTyPrim _ _ = Nothing
+
+||| A formation substituted along a substitution DERIVATION
+||| (ty-sub-cong-fix at refl, presupposed): one wrap; conclude
+||| computes the substituted spelling eagerly, and the caller caches
+||| the same spelling.
+export
+judSubTy : Deriv -> Ctx -> Ty -> JudTy -> JudTy
+judSubTy dS cx sp ft =
+  MkJudTy (DPresupTyL (DTySubCongFix dS (DTyRefl ft.deriv))) cx sp
+
+||| ℕ-elimination (el-nat-e): the motive's formation over ctx▷ℕ and
+||| the three premises, each at its motive instance.
+export
+judNatE : JudTy -> Jud -> Jud -> Jud -> Jud
+judNatE mot z s t =
+  MkJud (DElNatE mot.deriv z.deriv s.deriv t.deriv) t.ctx
+    (NatElim z.elem s.elem t.elem) (substTy mot.ty (Ext Id t.elem))
+
+-- ===== type formations by construction =====
+
+export
+judTyPrf : Jud -> JudTy
+judTyPrf p = MkJudTy (DTyPrf p.deriv) p.ctx (Prf p.elem)
+
+export
+judTyEl : Jud -> JudTy
+judTyEl a = MkJudTy (DTyEl a.deriv) a.ctx (El a.elem)
+
+export
+judTyPi : JudTy -> JudTy -> JudTy
+judTyPi a b = MkJudTy (DTyPi a.deriv b.deriv) a.ctx (Ty.PiTy a.ty b.ty)
+
+export
+judTySigma : JudTy -> JudTy -> JudTy
+judTySigma a b = MkJudTy (DTySigma a.deriv b.deriv) a.ctx (Ty.SigmaTy a.ty b.ty)
+
+||| The equality PROPOSITION's code (code-eq): the ambient type's
+||| formation and the two sides at it.
+export
+judCodeEq : JudTy -> Jud -> Jud -> Jud
+judCodeEq t l r =
+  MkJud (DCodeEq t.deriv l.deriv r.deriv) t.ctx
+    (Elem.EqTy l.elem r.elem t.ty) Ty.PropTy
+
+-- ===== formation projections =====
+-- The domain and codomain formations behind a function's Π, read by
+-- presupposition + inversion — one node each, deterministic, never
+-- reconstructed. The spellings are the caller's (it exposed the Π).
+
+export
+judInvPiDom : Jud -> Ty -> JudTy
+judInvPiDom f a = MkJudTy (DInvPiDom (DPresupElTy f.deriv)) f.ctx a
+
+export
+judInvPiCod : Jud -> Ty -> Ty -> JudTy
+judInvPiCod f a b = MkJudTy (DInvPiCod (DPresupElTy f.deriv)) (f.ctx :< a) b
+
 -- ===== equational rules =====
 
 export

--- a/src/idris/Nova/Elaboration/Jud.idr
+++ b/src/idris/Nova/Elaboration/Jud.idr
@@ -190,6 +190,33 @@ judTySigVars x jdelta k sp cx = do
     dA <- mA
     pure (DSubNExt dEs dA (DElVar d))
 
+||| A signature ELEMENT reference at a spine of plain variables —
+||| the shape of every hole USE at its own context (el-sig): the
+||| sub-norm chain reads off the judgment context, the conclusion
+||| type is the caller's spelling (untrusted, validated at
+||| consumption like everything here).
+export
+judSigVars : SigIdentifier -> JCtx -> Nat -> Elem -> Ty -> Ctx -> Maybe Jud
+judSigVars x jdelta k sp ty cx = do
+  dSub <- go jdelta k
+  pure (MkJud (DElSig x dSub) cx sp ty)
+ where
+  go : JCtx -> Nat -> Maybe Deriv
+  go [<] _ = Just DSubNEmpty
+  go (rest :< mA) d = do
+    dEs <- go rest (S d)
+    dA <- mA
+    pure (DSubNExt dEs dA (DElVar d))
+
+||| Pair introduction (el-sigma-i): the first component, the
+||| codomain family's formation over the extended context, the
+||| second component at the family's first-component instance.
+export
+judSigmaI : Jud -> JudTy -> Jud -> Jud
+judSigmaI u cod v =
+  MkJud (DElSigmaI u.deriv cod.deriv v.deriv) u.ctx
+    (SigmaIntro u.elem v.elem) (Ty.SigmaTy u.ty cod.ty)
+
 -- ===== type formations by construction =====
 
 export

--- a/src/idris/Nova/Elaboration/Jud.idr
+++ b/src/idris/Nova/Elaboration/Jud.idr
@@ -1,0 +1,153 @@
+||| Judgment-carrying elaboration: the working state
+||| (docs/NovaPipeline.txt, "Phase 3 end-state, revised").
+|||
+||| A Jud is a DERIVATION paired with its cached erasure — the
+||| context, spelling, and type the elaborator would otherwise carry
+||| bare. The derivation is untrusted data (the seat erases and
+||| replays through conclude, which remains the sole authority), so
+||| these constructors perform NO side-condition checks: the
+||| elaborator is the producer and writes down what it built; a wrong
+||| move surfaces as a seat rejection, exactly as today, never as an
+||| acceptance. What the constructors DO guarantee is the structural
+||| invariant the whole design rests on: no spelling travels without
+||| its derivation, so premise access is projection — reading a field
+||| of a Jud in hand — never inversion.
+|||
+||| Migration (strangler-fig, docs/NovaPipeline.txt): elaboration
+||| routes port to Jud-valued form one at a time; unported routes
+||| keep returning bare spellings and the emission pass
+||| (Nova.Kernel.Reconstruct) remains their adapter. This module is
+||| the seed: the judgment forms, their erasures, and the
+||| constructors the ⋆-discharge pilot needs. It grows with the port
+||| and is consumed by nothing yet.
+module Nova.Elaboration.Jud
+
+import Data.SnocList
+
+import Nova.Kernel.Syntax
+import Nova.Kernel.Subst
+import Nova.Kernel.Beta
+import Nova.Kernel.Derivation
+
+-- substitution and contraction reach the kernel's fuel-free walkers,
+-- which Idris cannot see terminating; totality is not this module's
+-- claim to make
+%default covering
+
+||| Γ ⊦ t : A, with the derivation.
+public export
+record Jud where
+  constructor MkJud
+  deriv : Deriv
+  ctx : Ctx
+  elem : Elem
+  ty : Ty
+
+||| Γ ⊦ A type, with the derivation.
+public export
+record JudTy where
+  constructor MkJudTy
+  deriv : Deriv
+  ctx : Ctx
+  ty : Ty
+
+||| Γ ⊦ t₀ ≐ t₁ : A, with the derivation.
+public export
+record JudEq where
+  constructor MkJudEq
+  deriv : Deriv
+  ctx : Ctx
+  lhs : Elem
+  rhs : Elem
+  ty : Ty
+
+||| Γ ⊦ A₀ ≐ A₁ type, with the derivation.
+public export
+record JudTyEq where
+  constructor MkJudTyEq
+  deriv : Deriv
+  ctx : Ctx
+  lhs : Ty
+  rhs : Ty
+
+-- ===== structural rules =====
+
+wkTy : Nat -> Ty -> Ty
+wkTy Z t = t
+wkTy (S n) t = wkTy n (substTy t Wk)
+
+||| ☐ᵢ at its context-assigned type (el-var).
+export
+judVar : Ctx -> Nat -> Maybe Jud
+judVar cx i = do
+  t <- go (toList (reverse cx)) i
+  pure (MkJud (DElVar i) cx (CtxVar i) (wkTy (S i) t))
+ where
+  go : List Ty -> Nat -> Maybe Ty
+  go [] _ = Nothing
+  go (t :: _) Z = Just t
+  go (_ :: rest) (S n) = go rest n
+
+||| λ-introduction (el-pi-i): the domain's formation and the body's
+||| judgment in the extended context.
+export
+judPiI : JudTy -> Jud -> Jud
+judPiI dom body =
+  MkJud (DElPiI dom.deriv body.deriv) dom.ctx
+    (PiIntro body.elem) (Ty.PiTy dom.ty body.ty)
+
+||| Application (el-pi-e): the function at a Π, the argument at its
+||| domain, the codomain's formation in the extended context. The
+||| producer asserts the domain fit; the seat checks it.
+export
+judPiE : Jud -> Jud -> JudTy -> Maybe Jud
+judPiE f e cod = do
+  let Ty.PiTy _ b = f.ty
+    | _ => Nothing
+  pure (MkJud (DElPiE f.deriv e.deriv cod.deriv) f.ctx
+          (PiApp f.elem e.elem) (substTy b (Ext Id e.elem)))
+
+||| Coercion along a type equation (el-ty-coe).
+export
+judCoe : JudTyEq -> Jud -> Jud
+judCoe eq j = MkJud (DElTyCoe eq.deriv j.deriv) j.ctx j.elem eq.rhs
+
+-- ===== equational rules =====
+
+export
+judRefl : Jud -> JudEq
+judRefl j = MkJudEq (DElRefl j.deriv) j.ctx j.elem j.elem j.ty
+
+export
+judSym : JudEq -> JudEq
+judSym e = MkJudEq (DElSym e.deriv) e.ctx e.rhs e.lhs e.ty
+
+||| Transitivity; the producer asserts the middles meet.
+export
+judTrans : JudEq -> JudEq -> JudEq
+judTrans a b = MkJudEq (DElTrans a.deriv b.deriv) a.ctx a.lhs b.rhs a.ty
+
+||| One ≜ contraction at a path (beta-at): the exposure link. The
+||| contraction is computed here — the one place a constructor does
+||| work — because the conclusion's spelling IS its result.
+export
+judBetaAt : Sig -> List Nat -> Jud -> Maybe JudEq
+judBetaAt sig p j = do
+  t' <- contractAtE sig p j.elem
+  pure (MkJudEq (DBetaAt p j.deriv) j.ctx j.elem t' j.ty)
+
+-- ===== presupposition projection =====
+-- The design's central dividend: the typing of a spelling in hand is
+-- a field read plus one node, never a re-derivation.
+
+export
+judEqLhs : JudEq -> Jud
+judEqLhs e = MkJud (DPresupElL e.deriv) e.ctx e.lhs e.ty
+
+export
+judEqRhs : JudEq -> Jud
+judEqRhs e = MkJud (DPresupElR e.deriv) e.ctx e.rhs e.ty
+
+export
+judElTy : Jud -> JudTy
+judElTy j = MkJudTy (DPresupElTy j.deriv) j.ctx j.ty

--- a/src/idris/Nova/Kernel/Derivation.idr
+++ b/src/idris/Nova/Kernel/Derivation.idr
@@ -443,6 +443,15 @@ data Deriv : Type where
   DNfExpandTy : Deriv -> Deriv
   ||| nf-eq: Γ ⊦ t₀ : A;  Γ ⊦ t₁ : A;  nf(t₀) = nf(t₁)
   DNfEq : Deriv -> Deriv -> Deriv
+  ||| share Δ D₀ D₁ — let-bound subderivation (admissible addition 3,
+  ||| docs/NovaDerivations.txt): D₀ concludes ONCE, under the carried
+  ||| context Δ; within D₁ the binding is cited by DRef, legal exactly
+  ||| at Δ. Sharing is explicit in the artifact — replay walks each
+  ||| bound derivation once, and conclude stays cache-free.
+  DShare : Ctx -> Deriv -> Deriv -> Deriv
+  ||| ⟨i⟩ — cite the i-th share binding (absolute index, outermost
+  ||| first)
+  DRef : Nat -> Deriv
   ||| nf-eq-ty
   DNfEqTy : Deriv -> Deriv -> Deriv
 
@@ -745,23 +754,29 @@ wkEl e = substElem e Wk
 
 -- ===== The checker =====
 
+||| The share environment: judgments concluded by enclosing DShare
+||| bindings, each with the context it was concluded under.
+public export
+ShareEnv : Type
+ShareEnv = List (Ctx, Judg)
+
 ||| Declared ahead: the spine helper below recurses into it, and the
 ||| ToS family (dual zone Γ ; Φ — Φ threaded as an input, exactly as
 ||| Γ is) is mutual with it.
 export
-conclude : Sig -> Ctx -> Deriv -> KM Judg
+conclude : ShareEnv -> Sig -> Ctx -> Deriv -> KM Judg
 
 ||| Γ ; Φ ⊦ 𝔄 qty
 export
-concludeQTy : Sig -> Ctx -> SnocList QTy -> Deriv -> KM QTy
+concludeQTy : ShareEnv -> Sig -> Ctx -> SnocList QTy -> Deriv -> KM QTy
 
 ||| Γ ; Φ ⊦ 𝕥 : 𝔄
 export
-concludeQTm : Sig -> Ctx -> SnocList QTy -> Deriv -> KM (QTm, QTy)
+concludeQTm : ShareEnv -> Sig -> Ctx -> SnocList QTy -> Deriv -> KM (QTm, QTy)
 
 ||| Γ ⊦ ς : Φ₀ ⇒ Φ₁ (Φ₀ the input, Φ₁ the output)
 export
-concludeQSub : Sig -> Ctx -> SnocList QTy -> Deriv -> KM (QSub, SnocList QTy)
+concludeQSub : ShareEnv -> Sig -> Ctx -> SnocList QTy -> Deriv -> KM (QSub, SnocList QTy)
 
 
 piProj : Ty -> Maybe (Ty, Ty)
@@ -784,59 +799,59 @@ sgCProj _ = Nothing
 ||| (grouped conclusions split into two nodes): the equation delivers
 ||| both spellings, the two formation premises are side-compared at
 ||| their own domains.
-tyBinInj : Sig -> Ctx -> String -> (Ty -> Maybe (Ty, Ty)) ->
+tyBinInj : ShareEnv -> Sig -> Ctx -> String -> (Ty -> Maybe (Ty, Ty)) ->
            Deriv -> Deriv -> Deriv -> KM (Ty, Ty, Ty, Ty)
-tyBinInj sig ctx rule proj dB0 dB1 dEq = do
-  (l, r) <- conclude sig ctx dEq >>= needTyEq
+tyBinInj env sig ctx rule proj dB0 dB1 dEq = do
+  (l, r) <- conclude env sig ctx dEq >>= needTyEq
   case (proj l, proj r) of
     (Just (a0, b0), Just (a1, b1)) => do
-      b0' <- conclude sig (ctx :< a0) dB0 >>= needTy
+      b0' <- conclude env sig (ctx :< a0) dB0 >>= needTy
       alphaTy rule b0' b0
-      b1' <- conclude sig (ctx :< a1) dB1 >>= needTy
+      b1' <- conclude env sig (ctx :< a1) dB1 >>= needTy
       alphaTy rule b1' b1
       pure (a0, a1, b0, b1)
     _ => kerr "derivation: \{rule}: equation not between the right formers"
 
-codeBinInj : Sig -> Ctx -> String -> (Elem -> Maybe (Elem, Elem)) ->
+codeBinInj : ShareEnv -> Sig -> Ctx -> String -> (Elem -> Maybe (Elem, Elem)) ->
              Deriv -> Deriv -> Deriv -> KM (Elem, Elem, Elem, Elem)
-codeBinInj sig ctx rule proj dB0 dB1 dEq = do
-  (l, r, ty) <- conclude sig ctx dEq >>= needElEq
+codeBinInj env sig ctx rule proj dB0 dB1 dEq = do
+  (l, r, ty) <- conclude env sig ctx dEq >>= needElEq
   alphaTy rule ty Ty.UniverseTy
   case (proj l, proj r) of
     (Just (a0, b0), Just (a1, b1)) => do
-      (b0', b0ty) <- conclude sig (ctx :< El a0) dB0 >>= needEl
+      (b0', b0ty) <- conclude env sig (ctx :< El a0) dB0 >>= needEl
       alphaTy rule b0ty Ty.UniverseTy
       alphaEl rule b0' b0
-      (b1', b1ty) <- conclude sig (ctx :< El a1) dB1 >>= needEl
+      (b1', b1ty) <- conclude env sig (ctx :< El a1) dB1 >>= needEl
       alphaTy rule b1ty Ty.UniverseTy
       alphaEl rule b1' b1
       pure (a0, a1, b0, b1)
     _ => kerr "derivation: \{rule}: equation not between the right formers"
 
-tyQuotInj : Sig -> Ctx -> Deriv -> Deriv -> Deriv -> KM (Ty, Ty, Elem, Elem)
-tyQuotInj sig ctx dR0 dR1 dEq = do
-  (l, r) <- conclude sig ctx dEq >>= needTyEq
+tyQuotInj : ShareEnv -> Sig -> Ctx -> Deriv -> Deriv -> Deriv -> KM (Ty, Ty, Elem, Elem)
+tyQuotInj env sig ctx dR0 dR1 dEq = do
+  (l, r) <- conclude env sig ctx dEq >>= needTyEq
   case (l, r) of
     (Ty.Quotient a0 r0, Ty.Quotient a1 r1) => do
-      (r0', r0ty) <- conclude sig (ctx :< a0 :< wkTy a0) dR0 >>= needEl
+      (r0', r0ty) <- conclude env sig (ctx :< a0 :< wkTy a0) dR0 >>= needEl
       alphaTy "ty-quot-inj" r0ty Ty.PropTy
       alphaEl "ty-quot-inj" r0' r0
-      (r1', r1ty) <- conclude sig (ctx :< a1 :< wkTy a1) dR1 >>= needEl
+      (r1', r1ty) <- conclude env sig (ctx :< a1 :< wkTy a1) dR1 >>= needEl
       alphaTy "ty-quot-inj" r1ty Ty.PropTy
       alphaEl "ty-quot-inj" r1' r1
       pure (a0, a1, r0, r1)
     _ => kerr "derivation: ty-quot-inj: equation not between quotients"
 
-codeQuotInj : Sig -> Ctx -> Deriv -> Deriv -> Deriv -> KM (Elem, Elem, Elem, Elem)
-codeQuotInj sig ctx dR0 dR1 dEq = do
-  (l, r, ty) <- conclude sig ctx dEq >>= needElEq
+codeQuotInj : ShareEnv -> Sig -> Ctx -> Deriv -> Deriv -> Deriv -> KM (Elem, Elem, Elem, Elem)
+codeQuotInj env sig ctx dR0 dR1 dEq = do
+  (l, r, ty) <- conclude env sig ctx dEq >>= needElEq
   alphaTy "code-quot-inj" ty Ty.UniverseTy
   case (l, r) of
     (Elem.QuotTy a0 r0, Elem.QuotTy a1 r1) => do
-      (r0', r0ty) <- conclude sig (ctx :< El a0 :< wkTy (El a0)) dR0 >>= needEl
+      (r0', r0ty) <- conclude env sig (ctx :< El a0 :< wkTy (El a0)) dR0 >>= needEl
       alphaTy "code-quot-inj" r0ty Ty.PropTy
       alphaEl "code-quot-inj" r0' r0
-      (r1', r1ty) <- conclude sig (ctx :< El a1 :< wkTy (El a1)) dR1 >>= needEl
+      (r1', r1ty) <- conclude env sig (ctx :< El a1 :< wkTy (El a1)) dR1 >>= needEl
       alphaTy "code-quot-inj" r1ty Ty.PropTy
       alphaEl "code-quot-inj" r1' r1
       pure (a0, a1, r0, r1)
@@ -872,9 +887,9 @@ qArity sg k = do
 ||| A spine checked entrywise against a reflected telescope: each
 ||| entry's concluded type must match the telescope's, instantiated
 ||| by the earlier entries.
-qSpine : String -> Sig -> Ctx -> List Deriv -> List Ty -> KM (List Elem)
-qSpine rule sig ctx ds tel = do
-  pairs <- traverse (\d => conclude sig ctx d >>= needEl) ds
+qSpine : ShareEnv -> String -> Sig -> Ctx -> List Deriv -> List Ty -> KM (List Elem)
+qSpine env rule sig ctx ds tel = do
+  pairs <- traverse (\d => conclude env sig ctx d >>= needEl) ds
   let args = map fst pairs
   if length args /= length tel
     then kerr "derivation: \{rule}: spine length mismatch"
@@ -907,9 +922,9 @@ qSortCtx sig ctx sg sj = do
 ||| The eliminator rules' shared tail: the index spine at the sort's
 ||| reflected arity, the scrutinee at the sort instance, the sort's
 ||| motive.
-qElimEnd : Sig -> Ctx -> QSig -> List Ty -> Nat -> List Deriv -> Deriv ->
+qElimEnd : ShareEnv -> Sig -> Ctx -> QSig -> List Ty -> Nat -> List Deriv -> Deriv ->
            KM (List Elem, Elem, Ty)
-qElimEnd sig ctx sg mots k dSp dW = do
+qElimEnd env sig ctx sg mots k dSp dW = do
   entry <- case qEntry sg k of
              Just e => pure e
              Nothing => kerr "derivation: el-qiit-elim: sort out of range"
@@ -917,8 +932,8 @@ qElimEnd sig ctx sg mots k dSp dW = do
     QKSort => pure ()
     _ => kerr "derivation: el-qiit-elim: not a sort position"
   (tel, _, _) <- liftQE (reflTel sg (qwAt k) entry)
-  es <- qSpine "el-qiit-elim" sig ctx dSp tel
-  (w, wty) <- conclude sig ctx dW >>= needEl
+  es <- qSpine env "el-qiit-elim" sig ctx dSp tel
+  (w, wty) <- conclude env sig ctx dW >>= needEl
   alphaTy "el-qiit-elim (scrutinee)" wty (QSort sg k (cast es))
   o <- case qOrdinal QKSort sg k of
          Just x => pure x
@@ -929,38 +944,38 @@ qElimEnd sig ctx sg mots k dSp dW = do
   pure (es, w, motK)
 
 -- type formation
-conclude sig ctx DTyZero = pure (JTy Ty.ZeroTy)
-conclude sig ctx DTyOne = pure (JTy Ty.OneTy)
-conclude sig ctx DTyNat = pure (JTy Ty.NatTy)
-conclude sig ctx DTyUniv = pure (JTy Ty.UniverseTy)
-conclude sig ctx DTyProp = pure (JTy Ty.PropTy)
-conclude sig ctx (DTyPi dA dB) = do
-  a <- conclude sig ctx dA >>= needTy
-  b <- conclude sig (ctx :< a) dB >>= needTy
+conclude env sig ctx DTyZero = pure (JTy Ty.ZeroTy)
+conclude env sig ctx DTyOne = pure (JTy Ty.OneTy)
+conclude env sig ctx DTyNat = pure (JTy Ty.NatTy)
+conclude env sig ctx DTyUniv = pure (JTy Ty.UniverseTy)
+conclude env sig ctx DTyProp = pure (JTy Ty.PropTy)
+conclude env sig ctx (DTyPi dA dB) = do
+  a <- conclude env sig ctx dA >>= needTy
+  b <- conclude env sig (ctx :< a) dB >>= needTy
   pure (JTy (Ty.PiTy a b))
-conclude sig ctx (DTySigma dA dB) = do
-  a <- conclude sig ctx dA >>= needTy
-  b <- conclude sig (ctx :< a) dB >>= needTy
+conclude env sig ctx (DTySigma dA dB) = do
+  a <- conclude env sig ctx dA >>= needTy
+  b <- conclude env sig (ctx :< a) dB >>= needTy
   pure (JTy (Ty.SigmaTy a b))
-conclude sig ctx (DTySum dA dB) = do
-  a <- conclude sig ctx dA >>= needTy
-  b <- conclude sig ctx dB >>= needTy
+conclude env sig ctx (DTySum dA dB) = do
+  a <- conclude env sig ctx dA >>= needTy
+  b <- conclude env sig ctx dB >>= needTy
   pure (JTy (Ty.SumTy a b))
-conclude sig ctx (DTyEl dA) = do
-  (a, ty) <- conclude sig ctx dA >>= needEl
+conclude env sig ctx (DTyEl dA) = do
+  (a, ty) <- conclude env sig ctx dA >>= needEl
   alphaTy "ty-el" ty Ty.UniverseTy
   pure (JTy (El a))
-conclude sig ctx (DTyPrf dP) = do
-  (p, ty) <- conclude sig ctx dP >>= needEl
+conclude env sig ctx (DTyPrf dP) = do
+  (p, ty) <- conclude env sig ctx dP >>= needEl
   alphaTy "ty-prf" ty Ty.PropTy
   pure (JTy (Prf p))
-conclude sig ctx (DTyQuot dA dR) = do
-  a <- conclude sig ctx dA >>= needTy
-  (r, rty) <- conclude sig (ctx :< a :< wkTy a) dR >>= needEl
+conclude env sig ctx (DTyQuot dA dR) = do
+  a <- conclude env sig ctx dA >>= needTy
+  (r, rty) <- conclude env sig (ctx :< a :< wkTy a) dR >>= needEl
   alphaTy "ty-quot" rty Ty.PropTy
   pure (JTy (Ty.Quotient a r))
-conclude sig ctx (DTySig x dSub) = do
-  (es, delta) <- conclude sig ctx dSub >>= needSubN
+conclude env sig ctx (DTySig x dSub) = do
+  (es, delta) <- conclude env sig ctx dSub >>= needSubN
   case sigLookup x sig of
     Just (SigTyDef gamma _ a) => do
       alphaCtx "ty-sig-var" delta gamma
@@ -976,12 +991,12 @@ conclude sig ctx (DTySig x dSub) = do
     else kerr "derivation: \{rule}: entry context mismatch"
 
 -- element typing
-conclude sig ctx (DElVar n) =
+conclude env sig ctx (DElVar n) =
   case ctxAt ctx n of
     Just a => pure (JEl (CtxVar n) a)
     Nothing => kerr "derivation: el-var: index out of range"
-conclude sig ctx (DElSig x dSub) = do
-  (es, delta) <- conclude sig ctx dSub >>= needSubN
+conclude env sig ctx (DElSig x dSub) = do
+  (es, delta) <- conclude env sig ctx dSub >>= needSubN
   case sigLookup x sig of
     Just (SigDef gamma _ _ a) => do
       if delta == gamma then pure ()
@@ -992,176 +1007,176 @@ conclude sig ctx (DElSig x dSub) = do
         else kerr "derivation: el-sig-decl: entry context mismatch"
       pure (JEl (Elem.SigVar x es) (substTy a (embed es)))
     _ => kerr "derivation: el-sig: no term entry '\{x}'"
-conclude sig ctx DCodeZero = pure (JEl Elem.ZeroTy Ty.UniverseTy)
-conclude sig ctx DCodeOne = pure (JEl Elem.OneTy Ty.UniverseTy)
-conclude sig ctx DCodeNat = pure (JEl Elem.NatTy Ty.UniverseTy)
-conclude sig ctx (DCodePi dA dB) = do
-  (a, aty) <- conclude sig ctx dA >>= needEl
+conclude env sig ctx DCodeZero = pure (JEl Elem.ZeroTy Ty.UniverseTy)
+conclude env sig ctx DCodeOne = pure (JEl Elem.OneTy Ty.UniverseTy)
+conclude env sig ctx DCodeNat = pure (JEl Elem.NatTy Ty.UniverseTy)
+conclude env sig ctx (DCodePi dA dB) = do
+  (a, aty) <- conclude env sig ctx dA >>= needEl
   alphaTy "code-pi" aty Ty.UniverseTy
-  (b, bty) <- conclude sig (ctx :< El a) dB >>= needEl
+  (b, bty) <- conclude env sig (ctx :< El a) dB >>= needEl
   alphaTy "code-pi" bty Ty.UniverseTy
   pure (JEl (Elem.PiTy a b) Ty.UniverseTy)
-conclude sig ctx (DCodeSigma dA dB) = do
-  (a, aty) <- conclude sig ctx dA >>= needEl
+conclude env sig ctx (DCodeSigma dA dB) = do
+  (a, aty) <- conclude env sig ctx dA >>= needEl
   alphaTy "code-sigma" aty Ty.UniverseTy
-  (b, bty) <- conclude sig (ctx :< El a) dB >>= needEl
+  (b, bty) <- conclude env sig (ctx :< El a) dB >>= needEl
   alphaTy "code-sigma" bty Ty.UniverseTy
   pure (JEl (Elem.SigmaTy a b) Ty.UniverseTy)
-conclude sig ctx (DCodeSum dA dB) = do
-  (a, aty) <- conclude sig ctx dA >>= needEl
+conclude env sig ctx (DCodeSum dA dB) = do
+  (a, aty) <- conclude env sig ctx dA >>= needEl
   alphaTy "code-sum" aty Ty.UniverseTy
-  (b, bty) <- conclude sig ctx dB >>= needEl
+  (b, bty) <- conclude env sig ctx dB >>= needEl
   alphaTy "code-sum" bty Ty.UniverseTy
   pure (JEl (Elem.SumTy a b) Ty.UniverseTy)
-conclude sig ctx (DCodeQuot dA dR) = do
-  (a, aty) <- conclude sig ctx dA >>= needEl
+conclude env sig ctx (DCodeQuot dA dR) = do
+  (a, aty) <- conclude env sig ctx dA >>= needEl
   alphaTy "code-quot" aty Ty.UniverseTy
-  (r, rty) <- conclude sig (ctx :< El a :< wkTy (El a)) dR >>= needEl
+  (r, rty) <- conclude env sig (ctx :< El a :< wkTy (El a)) dR >>= needEl
   alphaTy "code-quot" rty Ty.PropTy
   pure (JEl (Elem.QuotTy a r) Ty.UniverseTy)
-conclude sig ctx (DCodeEq dT dL dR) = do
-  t <- conclude sig ctx dT >>= needTy
-  (l, lty) <- conclude sig ctx dL >>= needEl
+conclude env sig ctx (DCodeEq dT dL dR) = do
+  t <- conclude env sig ctx dT >>= needTy
+  (l, lty) <- conclude env sig ctx dL >>= needEl
   alphaTy "code-eq" lty t
-  (r, rty) <- conclude sig ctx dR >>= needEl
+  (r, rty) <- conclude env sig ctx dR >>= needEl
   alphaTy "code-eq" rty t
   pure (JEl (Elem.EqTy l r t) Ty.PropTy)
-conclude sig ctx (DCodeSquash dA) = do
-  a <- conclude sig ctx dA >>= needTy
+conclude env sig ctx (DCodeSquash dA) = do
+  a <- conclude env sig ctx dA >>= needTy
   pure (JEl (Squash a) Ty.PropTy)
-conclude sig ctx (DElZeroE dA dT) = do
-  a <- conclude sig ctx dA >>= needTy
-  (t, tty) <- conclude sig ctx dT >>= needEl
+conclude env sig ctx (DElZeroE dA dT) = do
+  a <- conclude env sig ctx dA >>= needTy
+  (t, tty) <- conclude env sig ctx dT >>= needEl
   alphaTy "el-zero-e" tty Ty.ZeroTy
   pure (JEl (ZeroElim t) a)
-conclude sig ctx DElOneI = pure (JEl OneIntro Ty.OneTy)
-conclude sig ctx DElNatZ = pure (JEl NatIntro0 Ty.NatTy)
-conclude sig ctx (DElNatS dT) = do
-  (t, tty) <- conclude sig ctx dT >>= needEl
+conclude env sig ctx DElOneI = pure (JEl OneIntro Ty.OneTy)
+conclude env sig ctx DElNatZ = pure (JEl NatIntro0 Ty.NatTy)
+conclude env sig ctx (DElNatS dT) = do
+  (t, tty) <- conclude env sig ctx dT >>= needEl
   alphaTy "el-nat-s" tty Ty.NatTy
   pure (JEl (NatIntro1 t) Ty.NatTy)
-conclude sig ctx (DElNatE dMot dZ dS dT) = do
-  mot <- conclude sig (ctx :< Ty.NatTy) dMot >>= needTy
-  (z, zty) <- conclude sig ctx dZ >>= needEl
+conclude env sig ctx (DElNatE dMot dZ dS dT) = do
+  mot <- conclude env sig (ctx :< Ty.NatTy) dMot >>= needTy
+  (z, zty) <- conclude env sig ctx dZ >>= needEl
   alphaTy "el-nat-e (z)" zty (substTy mot (Ext Id NatIntro0))
-  (s, sty) <- conclude sig (ctx :< Ty.NatTy :< mot) dS >>= needEl
+  (s, sty) <- conclude env sig (ctx :< Ty.NatTy :< mot) dS >>= needEl
   alphaTy "el-nat-e (s)" sty
     (substTy mot (Chain (Ext Wk (NatIntro1 (CtxVar 0))) Wk))
-  (t, tty) <- conclude sig ctx dT >>= needEl
+  (t, tty) <- conclude env sig ctx dT >>= needEl
   alphaTy "el-nat-e (t)" tty Ty.NatTy
   pure (JEl (NatElim z s t) (substTy mot (Ext Id t)))
-conclude sig ctx (DElPiI dA dF) = do
-  a <- conclude sig ctx dA >>= needTy
-  (f, b) <- conclude sig (ctx :< a) dF >>= needEl
+conclude env sig ctx (DElPiI dA dF) = do
+  a <- conclude env sig ctx dA >>= needTy
+  (f, b) <- conclude env sig (ctx :< a) dF >>= needEl
   pure (JEl (PiIntro f) (Ty.PiTy a b))
-conclude sig ctx (DElPiE dF dE dB) = do
-  (f, fty) <- conclude sig ctx dF >>= needEl
+conclude env sig ctx (DElPiE dF dE dB) = do
+  (f, fty) <- conclude env sig ctx dF >>= needEl
   case fty of
     Ty.PiTy a b => do
-      (e, ety) <- conclude sig ctx dE >>= needEl
+      (e, ety) <- conclude env sig ctx dE >>= needEl
       alphaTy "el-pi-e (arg)" ety a
-      b' <- conclude sig (ctx :< a) dB >>= needTy
+      b' <- conclude env sig (ctx :< a) dB >>= needTy
       alphaTy "el-pi-e (cod)" b' b
       pure (JEl (PiApp f e) (substTy b (Ext Id e)))
     _ => kerr "derivation: el-pi-e: function premise not at a Π type"
-conclude sig ctx (DElLet dA dB) = do
-  (a, aty) <- conclude sig ctx dA >>= needEl
+conclude env sig ctx (DElLet dA dB) = do
+  (a, aty) <- conclude env sig ctx dA >>= needEl
   let hyp = Prf (Elem.EqTy (CtxVar 0) (wkEl a) (wkTy aty))
-  (b, bty) <- conclude sig (ctx :< aty :< hyp) dB >>= needEl
+  (b, bty) <- conclude env sig (ctx :< aty :< hyp) dB >>= needEl
   pure (JEl (Let a b) (substTy bty (Ext (Ext Id a) Star)))
-conclude sig ctx (DElSigmaI dA dB dV) = do
-  (a, aty) <- conclude sig ctx dA >>= needEl
-  b <- conclude sig (ctx :< aty) dB >>= needTy
-  (v, vty) <- conclude sig ctx dV >>= needEl
+conclude env sig ctx (DElSigmaI dA dB dV) = do
+  (a, aty) <- conclude env sig ctx dA >>= needEl
+  b <- conclude env sig (ctx :< aty) dB >>= needTy
+  (v, vty) <- conclude env sig ctx dV >>= needEl
   alphaTy "el-sigma-i" vty (substTy b (Ext Id a))
   pure (JEl (SigmaIntro a v) (Ty.SigmaTy aty b))
-conclude sig ctx (DElSigmaE1 dT) = do
-  (t, tty) <- conclude sig ctx dT >>= needEl
+conclude env sig ctx (DElSigmaE1 dT) = do
+  (t, tty) <- conclude env sig ctx dT >>= needEl
   case tty of
     Ty.SigmaTy a _ => pure (JEl (SigmaElim1 t) a)
     _ => kerr "derivation: el-sigma-e₁: premise not at a ⨯ type"
-conclude sig ctx (DElSigmaE2 dT) = do
-  (t, tty) <- conclude sig ctx dT >>= needEl
+conclude env sig ctx (DElSigmaE2 dT) = do
+  (t, tty) <- conclude env sig ctx dT >>= needEl
   case tty of
     Ty.SigmaTy _ b => pure (JEl (SigmaElim2 t) (substTy b (Ext Id (SigmaElim1 t))))
     _ => kerr "derivation: el-sigma-e₂: premise not at a ⨯ type"
-conclude sig ctx (DElSumI1 dA dB) = do
-  (a, aty) <- conclude sig ctx dA >>= needEl
-  b <- conclude sig ctx dB >>= needTy
+conclude env sig ctx (DElSumI1 dA dB) = do
+  (a, aty) <- conclude env sig ctx dA >>= needEl
+  b <- conclude env sig ctx dB >>= needTy
   pure (JEl (Inj1 a) (Ty.SumTy aty b))
-conclude sig ctx (DElSumI2 dB dA) = do
-  (b, bty) <- conclude sig ctx dB >>= needEl
-  a <- conclude sig ctx dA >>= needTy
+conclude env sig ctx (DElSumI2 dB dA) = do
+  (b, bty) <- conclude env sig ctx dB >>= needEl
+  a <- conclude env sig ctx dA >>= needTy
   pure (JEl (Inj2 b) (Ty.SumTy a bty))
-conclude sig ctx (DElSumE dT dC dL dR) = do
-  (t, tty) <- conclude sig ctx dT >>= needEl
+conclude env sig ctx (DElSumE dT dC dL dR) = do
+  (t, tty) <- conclude env sig ctx dT >>= needEl
   case tty of
     Ty.SumTy a b => do
-      c <- conclude sig (ctx :< Ty.SumTy a b) dC >>= needTy
-      (l, lty) <- conclude sig (ctx :< a) dL >>= needEl
+      c <- conclude env sig (ctx :< Ty.SumTy a b) dC >>= needTy
+      (l, lty) <- conclude env sig (ctx :< a) dL >>= needEl
       alphaTy "el-sum-e (l)" lty (substTy c (Ext Wk (Inj1 (CtxVar 0))))
-      (r, rty) <- conclude sig (ctx :< b) dR >>= needEl
+      (r, rty) <- conclude env sig (ctx :< b) dR >>= needEl
       alphaTy "el-sum-e (r)" rty (substTy c (Ext Wk (Inj2 (CtxVar 0))))
       pure (JEl (SumElim l r t) (substTy c (Ext Id t)))
     _ => kerr "derivation: el-sum-e: scrutinee not at a ⊎ type"
-conclude sig ctx (DElSquashI dT) = do
-  (_, a) <- conclude sig ctx dT >>= needEl
+conclude env sig ctx (DElSquashI dT) = do
+  (_, a) <- conclude env sig ctx dT >>= needEl
   pure (JEl Star (Prf (Squash a)))
-conclude sig ctx (DElEqI dEq) = do
-  (a0, a1, a) <- conclude sig ctx dEq >>= needElEq
+conclude env sig ctx (DElEqI dEq) = do
+  (a0, a1, a) <- conclude env sig ctx dEq >>= needElEq
   pure (JEl Star (Prf (Elem.EqTy a0 a1 a)))
-conclude sig ctx (DElSquashEPrf dQ dS dT) = do
-  (q, qty) <- conclude sig ctx dQ >>= needEl
+conclude env sig ctx (DElSquashEPrf dQ dS dT) = do
+  (q, qty) <- conclude env sig ctx dQ >>= needEl
   alphaTy "el-squash-e-prf (q)" qty Ty.PropTy
-  (_, sty) <- conclude sig ctx dS >>= needEl
+  (_, sty) <- conclude env sig ctx dS >>= needEl
   case sty of
     Prf (Squash a) => do
-      (_, tty) <- conclude sig (ctx :< a) dT >>= needEl
+      (_, tty) <- conclude env sig (ctx :< a) dT >>= needEl
       alphaTy "el-squash-e-prf (t)" tty (wkTy (Prf q))
       pure (JEl Star (Prf q))
     _ => kerr "derivation: el-squash-e-prf: premise not at a squash"
-conclude sig ctx (DElTyCoe dEq dA) = do
-  (a0, a1) <- conclude sig ctx dEq >>= needTyEq
-  (a, aty) <- conclude sig ctx dA >>= needEl
+conclude env sig ctx (DElTyCoe dEq dA) = do
+  (a0, a1) <- conclude env sig ctx dEq >>= needTyEq
+  (a, aty) <- conclude env sig ctx dA >>= needEl
   alphaTy "el-ty-coe" aty a0
   pure (JEl a a1)
 
 -- equality: equivalence, coercion, reflection
-conclude sig ctx (DElRefl dT) = do
-  (t, a) <- conclude sig ctx dT >>= needEl
+conclude env sig ctx (DElRefl dT) = do
+  (t, a) <- conclude env sig ctx dT >>= needEl
   pure (JElEq t t a)
-conclude sig ctx (DElSym d) = do
-  (t0, t1, a) <- conclude sig ctx d >>= needElEq
+conclude env sig ctx (DElSym d) = do
+  (t0, t1, a) <- conclude env sig ctx d >>= needElEq
   pure (JElEq t1 t0 a)
-conclude sig ctx (DElTrans d01 d12) = do
-  (t0, t1, a) <- conclude sig ctx d01 >>= needElEq
-  (t1', t2, a') <- conclude sig ctx d12 >>= needElEq
+conclude env sig ctx (DElTrans d01 d12) = do
+  (t0, t1, a) <- conclude env sig ctx d01 >>= needElEq
+  (t1', t2, a') <- conclude env sig ctx d12 >>= needElEq
   alphaEl "el-trans (middle)" t1' t1
   alphaTy "el-trans (type)" a' a
   pure (JElEq t0 t2 a)
-conclude sig ctx (DTyRefl dT) = do
-  a <- conclude sig ctx dT >>= needTy
+conclude env sig ctx (DTyRefl dT) = do
+  a <- conclude env sig ctx dT >>= needTy
   pure (JTyEq a a)
-conclude sig ctx (DTySym d) = do
-  (a0, a1) <- conclude sig ctx d >>= needTyEq
+conclude env sig ctx (DTySym d) = do
+  (a0, a1) <- conclude env sig ctx d >>= needTyEq
   pure (JTyEq a1 a0)
-conclude sig ctx (DTyTrans d01 d12) = do
-  (a0, a1) <- conclude sig ctx d01 >>= needTyEq
-  (a1', a2) <- conclude sig ctx d12 >>= needTyEq
+conclude env sig ctx (DTyTrans d01 d12) = do
+  (a0, a1) <- conclude env sig ctx d01 >>= needTyEq
+  (a1', a2) <- conclude env sig ctx d12 >>= needTyEq
   alphaTy "ty-trans (middle)" a1' a1
   pure (JTyEq a0 a2)
-conclude sig ctx (DElEqTyCoe dTyEq dEq) = do
-  (a0, a1) <- conclude sig ctx dTyEq >>= needTyEq
-  (t0, t1, a) <- conclude sig ctx dEq >>= needElEq
+conclude env sig ctx (DElEqTyCoe dTyEq dEq) = do
+  (a0, a1) <- conclude env sig ctx dTyEq >>= needTyEq
+  (t0, t1, a) <- conclude env sig ctx dEq >>= needElEq
   alphaTy "el-eq-ty-coe" a a0
   pure (JElEq t0 t1 a1)
-conclude sig ctx (DElReflect dS) = do
-  (_, sty) <- conclude sig ctx dS >>= needEl
+conclude env sig ctx (DElReflect dS) = do
+  (_, sty) <- conclude env sig ctx dS >>= needEl
   case sty of
     Prf (Elem.EqTy a0 a1 a) => pure (JElEq a0 a1 a)
     _ => kerr "derivation: el-reflect: premise not at a literal equality prop"
-conclude sig ctx (DElSigEq pos dSub) = do
-  (es, delta) <- conclude sig ctx dSub >>= needSubN
+conclude env sig ctx (DElSigEq pos dSub) = do
+  (es, delta) <- conclude env sig ctx dSub >>= needSubN
   case getAt pos (toList sig) of
     Just (SigEq gamma a0 a1 a) => do
       if delta == gamma then pure ()
@@ -1169,8 +1184,8 @@ conclude sig ctx (DElSigEq pos dSub) = do
       pure (JElEq (substElem a0 (embed es)) (substElem a1 (embed es))
                   (substTy a (embed es)))
     _ => kerr "derivation: el-sig-eq: no constraint entry at position \{show pos}"
-conclude sig ctx (DTySigEq pos dSub) = do
-  (es, delta) <- conclude sig ctx dSub >>= needSubN
+conclude env sig ctx (DTySigEq pos dSub) = do
+  (es, delta) <- conclude env sig ctx dSub >>= needSubN
   case getAt pos (toList sig) of
     Just (SigTyEq gamma a0 a1) => do
       if delta == gamma then pure ()
@@ -1179,59 +1194,59 @@ conclude sig ctx (DTySigEq pos dSub) = do
     _ => kerr "derivation: ty-sig-eq: no type constraint at position \{show pos}"
 
 -- equality: props and η
-conclude sig ctx (DElZeroProp d0 d1) = do
-  (t0, ty0) <- conclude sig ctx d0 >>= needEl
+conclude env sig ctx (DElZeroProp d0 d1) = do
+  (t0, ty0) <- conclude env sig ctx d0 >>= needEl
   alphaTy "el-zero-prop" ty0 Ty.ZeroTy
-  (t1, ty1) <- conclude sig ctx d1 >>= needEl
+  (t1, ty1) <- conclude env sig ctx d1 >>= needEl
   alphaTy "el-zero-prop" ty1 Ty.ZeroTy
   pure (JElEq t0 t1 Ty.ZeroTy)
-conclude sig ctx (DElOneProp d0 d1) = do
-  (t0, ty0) <- conclude sig ctx d0 >>= needEl
+conclude env sig ctx (DElOneProp d0 d1) = do
+  (t0, ty0) <- conclude env sig ctx d0 >>= needEl
   alphaTy "el-one-prop" ty0 Ty.OneTy
-  (t1, ty1) <- conclude sig ctx d1 >>= needEl
+  (t1, ty1) <- conclude env sig ctx d1 >>= needEl
   alphaTy "el-one-prop" ty1 Ty.OneTy
   pure (JElEq t0 t1 Ty.OneTy)
-conclude sig ctx (DElPrfProp d0 d1) = do
-  (t0, ty0) <- conclude sig ctx d0 >>= needEl
+conclude env sig ctx (DElPrfProp d0 d1) = do
+  (t0, ty0) <- conclude env sig ctx d0 >>= needEl
   case ty0 of
     Prf p => do
-      (t1, ty1) <- conclude sig ctx d1 >>= needEl
+      (t1, ty1) <- conclude env sig ctx d1 >>= needEl
       alphaTy "el-prf-prop" ty1 (Prf p)
       pure (JElEq t0 t1 (Prf p))
     _ => kerr "derivation: el-prf-prop: premise not at a Prf type"
-conclude sig ctx (DCodePropEq dP dQ dS dT) = do
-  (p, pty) <- conclude sig ctx dP >>= needEl
+conclude env sig ctx (DCodePropEq dP dQ dS dT) = do
+  (p, pty) <- conclude env sig ctx dP >>= needEl
   alphaTy "code-prop-eq" pty Ty.PropTy
-  (q, qty) <- conclude sig ctx dQ >>= needEl
+  (q, qty) <- conclude env sig ctx dQ >>= needEl
   alphaTy "code-prop-eq" qty Ty.PropTy
-  (_, sty) <- conclude sig (ctx :< Prf p) dS >>= needEl
+  (_, sty) <- conclude env sig (ctx :< Prf p) dS >>= needEl
   alphaTy "code-prop-eq (→)" sty (wkTy (Prf q))
-  (_, tty) <- conclude sig (ctx :< Prf q) dT >>= needEl
+  (_, tty) <- conclude env sig (ctx :< Prf q) dT >>= needEl
   alphaTy "code-prop-eq (←)" tty (wkTy (Prf p))
   pure (JElEq p q Ty.PropTy)
-conclude sig ctx (DElPiEta dF0 dF1 dEq) = do
-  (f0, f0ty) <- conclude sig ctx dF0 >>= needEl
+conclude env sig ctx (DElPiEta dF0 dF1 dEq) = do
+  (f0, f0ty) <- conclude env sig ctx dF0 >>= needEl
   case f0ty of
     Ty.PiTy a b => do
-      (f1, f1ty) <- conclude sig ctx dF1 >>= needEl
+      (f1, f1ty) <- conclude env sig ctx dF1 >>= needEl
       alphaTy "el-pi-eta (f₁)" f1ty (Ty.PiTy a b)
-      (l, r, ety) <- conclude sig (ctx :< a) dEq >>= needElEq
+      (l, r, ety) <- conclude env sig (ctx :< a) dEq >>= needElEq
       alphaEl "el-pi-eta (l)" l (PiApp (wkEl f0) (CtxVar 0))
       alphaEl "el-pi-eta (r)" r (PiApp (wkEl f1) (CtxVar 0))
       alphaTy "el-pi-eta (ty)" ety b
       pure (JElEq f0 f1 (Ty.PiTy a b))
     _ => kerr "derivation: el-pi-eta: candidates not at a Π type"
-conclude sig ctx (DElSigmaEta dT0 dT1 dP1 dP2) = do
-  (t0, t0ty) <- conclude sig ctx dT0 >>= needEl
+conclude env sig ctx (DElSigmaEta dT0 dT1 dP1 dP2) = do
+  (t0, t0ty) <- conclude env sig ctx dT0 >>= needEl
   case t0ty of
     Ty.SigmaTy a b => do
-      (t1, t1ty) <- conclude sig ctx dT1 >>= needEl
+      (t1, t1ty) <- conclude env sig ctx dT1 >>= needEl
       alphaTy "el-sigma-eta (t₁)" t1ty (Ty.SigmaTy a b)
-      (p1l, p1r, p1ty) <- conclude sig ctx dP1 >>= needElEq
+      (p1l, p1r, p1ty) <- conclude env sig ctx dP1 >>= needElEq
       alphaEl "el-sigma-eta (π₁ l)" p1l (SigmaElim1 t0)
       alphaEl "el-sigma-eta (π₁ r)" p1r (SigmaElim1 t1)
       alphaTy "el-sigma-eta (π₁ ty)" p1ty a
-      (p2l, p2r, p2ty) <- conclude sig ctx dP2 >>= needElEq
+      (p2l, p2r, p2ty) <- conclude env sig ctx dP2 >>= needElEq
       alphaEl "el-sigma-eta (π₂ l)" p2l (SigmaElim2 t0)
       alphaEl "el-sigma-eta (π₂ r)" p2r (SigmaElim2 t1)
       alphaTy "el-sigma-eta (π₂ ty)" p2ty (substTy b (Ext Id (SigmaElim1 t0)))
@@ -1239,468 +1254,468 @@ conclude sig ctx (DElSigmaEta dT0 dT1 dP1 dP2) = do
     _ => kerr "derivation: el-sigma-eta: candidates not at a ⨯ type"
 
 -- equality: congruence
-conclude sig ctx (DElLamCong dA dF) = do
-  a <- conclude sig ctx dA >>= needTy
-  (f0, f1, b) <- conclude sig (ctx :< a) dF >>= needElEq
+conclude env sig ctx (DElLamCong dA dF) = do
+  a <- conclude env sig ctx dA >>= needTy
+  (f0, f1, b) <- conclude env sig (ctx :< a) dF >>= needElEq
   pure (JElEq (PiIntro f0) (PiIntro f1) (Ty.PiTy a b))
-conclude sig ctx (DElAppCong dF dA dB) = do
-  (f0, f1, fty) <- conclude sig ctx dF >>= needElEq
+conclude env sig ctx (DElAppCong dF dA dB) = do
+  (f0, f1, fty) <- conclude env sig ctx dF >>= needElEq
   case fty of
     Ty.PiTy a b => do
-      (a0, a1, aty) <- conclude sig ctx dA >>= needElEq
+      (a0, a1, aty) <- conclude env sig ctx dA >>= needElEq
       alphaTy "el-app-cong (arg)" aty a
-      b' <- conclude sig (ctx :< a) dB >>= needTy
+      b' <- conclude env sig (ctx :< a) dB >>= needTy
       alphaTy "el-app-cong (cod)" b' b
       pure (JElEq (PiApp f0 a0) (PiApp f1 a1) (substTy b (Ext Id a1)))
     _ => kerr "derivation: el-app-cong: premise not at a Π type"
-conclude sig ctx (DElSucCong d) = do
-  (t0, t1, a) <- conclude sig ctx d >>= needElEq
+conclude env sig ctx (DElSucCong d) = do
+  (t0, t1, a) <- conclude env sig ctx d >>= needElEq
   alphaTy "el-suc-cong" a Ty.NatTy
   pure (JElEq (NatIntro1 t0) (NatIntro1 t1) Ty.NatTy)
-conclude sig ctx (DElPairCong dA dB dV) = do
-  (a0, a1, aty) <- conclude sig ctx dA >>= needElEq
-  b <- conclude sig (ctx :< aty) dB >>= needTy
-  (b0, b1, vty) <- conclude sig ctx dV >>= needElEq
+conclude env sig ctx (DElPairCong dA dB dV) = do
+  (a0, a1, aty) <- conclude env sig ctx dA >>= needElEq
+  b <- conclude env sig (ctx :< aty) dB >>= needTy
+  (b0, b1, vty) <- conclude env sig ctx dV >>= needElEq
   alphaTy "el-pair-cong" vty (substTy b (Ext Id a1))
   pure (JElEq (SigmaIntro a0 b0) (SigmaIntro a1 b1) (Ty.SigmaTy aty b))
-conclude sig ctx (DElProj1Cong d) = do
-  (t0, t1, tty) <- conclude sig ctx d >>= needElEq
+conclude env sig ctx (DElProj1Cong d) = do
+  (t0, t1, tty) <- conclude env sig ctx d >>= needElEq
   case tty of
     Ty.SigmaTy a _ => pure (JElEq (SigmaElim1 t0) (SigmaElim1 t1) a)
     _ => kerr "derivation: el-proj₁-cong: premise not at a ⨯ type"
-conclude sig ctx (DElProj2Cong d) = do
-  (t0, t1, tty) <- conclude sig ctx d >>= needElEq
+conclude env sig ctx (DElProj2Cong d) = do
+  (t0, t1, tty) <- conclude env sig ctx d >>= needElEq
   case tty of
     Ty.SigmaTy _ b =>
       pure (JElEq (SigmaElim2 t0) (SigmaElim2 t1)
                   (substTy b (Ext Id (SigmaElim1 t1))))
     _ => kerr "derivation: el-proj₂-cong: premise not at a ⨯ type"
-conclude sig ctx (DTyPiCong dD dC) = do
-  (a0, a1) <- conclude sig ctx dD >>= needTyEq
-  (b0, b1) <- conclude sig (ctx :< a1) dC >>= needTyEq
+conclude env sig ctx (DTyPiCong dD dC) = do
+  (a0, a1) <- conclude env sig ctx dD >>= needTyEq
+  (b0, b1) <- conclude env sig (ctx :< a1) dC >>= needTyEq
   pure (JTyEq (Ty.PiTy a0 b0) (Ty.PiTy a1 b1))
-conclude sig ctx (DTySigmaCong dD dC) = do
-  (a0, a1) <- conclude sig ctx dD >>= needTyEq
-  (b0, b1) <- conclude sig (ctx :< a1) dC >>= needTyEq
+conclude env sig ctx (DTySigmaCong dD dC) = do
+  (a0, a1) <- conclude env sig ctx dD >>= needTyEq
+  (b0, b1) <- conclude env sig (ctx :< a1) dC >>= needTyEq
   pure (JTyEq (Ty.SigmaTy a0 b0) (Ty.SigmaTy a1 b1))
-conclude sig ctx (DTySumCong dL dR) = do
-  (a0, a1) <- conclude sig ctx dL >>= needTyEq
-  (b0, b1) <- conclude sig ctx dR >>= needTyEq
+conclude env sig ctx (DTySumCong dL dR) = do
+  (a0, a1) <- conclude env sig ctx dL >>= needTyEq
+  (b0, b1) <- conclude env sig ctx dR >>= needTyEq
   pure (JTyEq (Ty.SumTy a0 b0) (Ty.SumTy a1 b1))
-conclude sig ctx (DTyQuotCong dA dR) = do
-  (a0, a1) <- conclude sig ctx dA >>= needTyEq
-  (r0, r1, rty) <- conclude sig (ctx :< a1 :< wkTy a1) dR >>= needElEq
+conclude env sig ctx (DTyQuotCong dA dR) = do
+  (a0, a1) <- conclude env sig ctx dA >>= needTyEq
+  (r0, r1, rty) <- conclude env sig (ctx :< a1 :< wkTy a1) dR >>= needElEq
   alphaTy "ty-quot-cong" rty Ty.PropTy
   pure (JTyEq (Ty.Quotient a0 r0) (Ty.Quotient a1 r1))
-conclude sig ctx (DTyElCong d) = do
-  (a, b, ty) <- conclude sig ctx d >>= needElEq
+conclude env sig ctx (DTyElCong d) = do
+  (a, b, ty) <- conclude env sig ctx d >>= needElEq
   alphaTy "ty-el-cong" ty Ty.UniverseTy
   pure (JTyEq (El a) (El b))
-conclude sig ctx (DTyPrfCong d) = do
-  (p, q, ty) <- conclude sig ctx d >>= needElEq
+conclude env sig ctx (DTyPrfCong d) = do
+  (p, q, ty) <- conclude env sig ctx d >>= needElEq
   alphaTy "ty-prf-cong" ty Ty.PropTy
   pure (JTyEq (Prf p) (Prf q))
 
 
 -- eliminator and remaining congruences
-conclude sig ctx (DElNatECong dMot dZ dS dT) = do
-  mot <- conclude sig (ctx :< Ty.NatTy) dMot >>= needTy
-  (z0, z1, zty) <- conclude sig ctx dZ >>= needElEq
+conclude env sig ctx (DElNatECong dMot dZ dS dT) = do
+  mot <- conclude env sig (ctx :< Ty.NatTy) dMot >>= needTy
+  (z0, z1, zty) <- conclude env sig ctx dZ >>= needElEq
   alphaTy "el-nat-e-cong (z)" zty (substTy mot (Ext Id NatIntro0))
-  (s0, s1, sty) <- conclude sig (ctx :< Ty.NatTy :< mot) dS >>= needElEq
+  (s0, s1, sty) <- conclude env sig (ctx :< Ty.NatTy :< mot) dS >>= needElEq
   alphaTy "el-nat-e-cong (s)" sty
     (substTy mot (Chain (Ext Wk (NatIntro1 (CtxVar 0))) Wk))
-  (t0, t1, tty) <- conclude sig ctx dT >>= needElEq
+  (t0, t1, tty) <- conclude env sig ctx dT >>= needElEq
   alphaTy "el-nat-e-cong (t)" tty Ty.NatTy
   pure (JElEq (NatElim z0 s0 t0) (NatElim z1 s1 t1) (substTy mot (Ext Id t1)))
-conclude sig ctx (DElSumECong dT dC dL dR) = do
-  (t0, t1, tty) <- conclude sig ctx dT >>= needElEq
+conclude env sig ctx (DElSumECong dT dC dL dR) = do
+  (t0, t1, tty) <- conclude env sig ctx dT >>= needElEq
   case tty of
     Ty.SumTy a b => do
-      c <- conclude sig (ctx :< Ty.SumTy a b) dC >>= needTy
-      (l0, l1, lty) <- conclude sig (ctx :< a) dL >>= needElEq
+      c <- conclude env sig (ctx :< Ty.SumTy a b) dC >>= needTy
+      (l0, l1, lty) <- conclude env sig (ctx :< a) dL >>= needElEq
       alphaTy "el-sum-e-cong (l)" lty (substTy c (Ext Wk (Inj1 (CtxVar 0))))
-      (r0, r1, rty) <- conclude sig (ctx :< b) dR >>= needElEq
+      (r0, r1, rty) <- conclude env sig (ctx :< b) dR >>= needElEq
       alphaTy "el-sum-e-cong (r)" rty (substTy c (Ext Wk (Inj2 (CtxVar 0))))
       pure (JElEq (SumElim l0 r0 t0) (SumElim l1 r1 t1) (substTy c (Ext Id t1)))
     _ => kerr "derivation: el-sum-e-cong: scrutinees not at a ⊎ type"
-conclude sig ctx (DElZeroECong dA d0 d1) = do
-  a <- conclude sig ctx dA >>= needTy
-  (t0, t0ty) <- conclude sig ctx d0 >>= needEl
+conclude env sig ctx (DElZeroECong dA d0 d1) = do
+  a <- conclude env sig ctx dA >>= needTy
+  (t0, t0ty) <- conclude env sig ctx d0 >>= needEl
   alphaTy "el-zero-e-cong" t0ty Ty.ZeroTy
-  (t1, t1ty) <- conclude sig ctx d1 >>= needEl
+  (t1, t1ty) <- conclude env sig ctx d1 >>= needEl
   alphaTy "el-zero-e-cong" t1ty Ty.ZeroTy
   pure (JElEq (ZeroElim t0) (ZeroElim t1) a)
-conclude sig ctx (DElQuotECong dQ dB dF0 dF1 dW0 dW1 dFeq) = do
-  (q0, q1, qty) <- conclude sig ctx dQ >>= needElEq
+conclude env sig ctx (DElQuotECong dQ dB dF0 dF1 dW0 dW1 dFeq) = do
+  (q0, q1, qty) <- conclude env sig ctx dQ >>= needElEq
   case qty of
     Ty.Quotient a r => do
-      b <- conclude sig (ctx :< Ty.Quotient a r) dB >>= needTy
+      b <- conclude env sig (ctx :< Ty.Quotient a r) dB >>= needTy
       let cse = substTy b (Ext Wk (Class (CtxVar 0)))
-      (f0, f0ty) <- conclude sig (ctx :< a) dF0 >>= needEl
+      (f0, f0ty) <- conclude env sig (ctx :< a) dF0 >>= needEl
       alphaTy "el-quot-e-cong (f₀)" f0ty cse
-      (f1, f1ty) <- conclude sig (ctx :< a) dF1 >>= needEl
+      (f1, f1ty) <- conclude env sig (ctx :< a) dF1 >>= needEl
       alphaTy "el-quot-e-cong (f₁)" f1ty cse
       let wk3 = Chain Wk (Chain Wk Wk)
       let wdCtx = ctx :< a :< wkTy a :< Prf r
       let wdTy = substTy b (Ext wk3 (Class (CtxVar 2)))
-      (w0l, w0r, w0ty) <- conclude sig wdCtx dW0 >>= needElEq
+      (w0l, w0r, w0ty) <- conclude env sig wdCtx dW0 >>= needElEq
       alphaEl "el-quot-e-cong (wd₀ l)" w0l (substElem f0 (Ext wk3 (CtxVar 2)))
       alphaEl "el-quot-e-cong (wd₀ r)" w0r (substElem f0 (Ext wk3 (CtxVar 1)))
       alphaTy "el-quot-e-cong (wd₀ ty)" w0ty wdTy
-      (w1l, w1r, w1ty) <- conclude sig wdCtx dW1 >>= needElEq
+      (w1l, w1r, w1ty) <- conclude env sig wdCtx dW1 >>= needElEq
       alphaEl "el-quot-e-cong (wd₁ l)" w1l (substElem f1 (Ext wk3 (CtxVar 2)))
       alphaEl "el-quot-e-cong (wd₁ r)" w1r (substElem f1 (Ext wk3 (CtxVar 1)))
       alphaTy "el-quot-e-cong (wd₁ ty)" w1ty wdTy
-      (fl, fr, fety) <- conclude sig (ctx :< a) dFeq >>= needElEq
+      (fl, fr, fety) <- conclude env sig (ctx :< a) dFeq >>= needElEq
       alphaEl "el-quot-e-cong (f⁼ l)" fl f0
       alphaEl "el-quot-e-cong (f⁼ r)" fr f1
       alphaTy "el-quot-e-cong (f⁼ ty)" fety cse
       pure (JElEq (QuotElim f0 q0) (QuotElim f1 q1) (substTy b (Ext Id q1)))
     _ => kerr "derivation: el-quot-e-cong: scrutinees not at a quotient type"
-conclude sig ctx (DElLetCong dA dB) = do
-  (a0, a1, aty) <- conclude sig ctx dA >>= needElEq
+conclude env sig ctx (DElLetCong dA dB) = do
+  (a0, a1, aty) <- conclude env sig ctx dA >>= needElEq
   let hyp = Prf (Elem.EqTy (CtxVar 0) (wkEl a1) (wkTy aty))
-  (b0, b1, bty) <- conclude sig (ctx :< aty :< hyp) dB >>= needElEq
+  (b0, b1, bty) <- conclude env sig (ctx :< aty :< hyp) dB >>= needElEq
   pure (JElEq (Let a0 b0) (Let a1 b1) (substTy bty (Ext (Ext Id a1) Star)))
-conclude sig ctx (DElClassCong dA dR) = do
-  (a0, a1, aty) <- conclude sig ctx dA >>= needElEq
-  (r, rty) <- conclude sig (ctx :< aty :< wkTy aty) dR >>= needEl
+conclude env sig ctx (DElClassCong dA dR) = do
+  (a0, a1, aty) <- conclude env sig ctx dA >>= needElEq
+  (r, rty) <- conclude env sig (ctx :< aty :< wkTy aty) dR >>= needEl
   alphaTy "el-class-cong" rty Ty.PropTy
   pure (JElEq (Class a0) (Class a1) (Ty.Quotient aty r))
-conclude sig ctx (DElInj1Cong dA dB) = do
-  (a0, a1, aty) <- conclude sig ctx dA >>= needElEq
-  b <- conclude sig ctx dB >>= needTy
+conclude env sig ctx (DElInj1Cong dA dB) = do
+  (a0, a1, aty) <- conclude env sig ctx dA >>= needElEq
+  b <- conclude env sig ctx dB >>= needTy
   pure (JElEq (Inj1 a0) (Inj1 a1) (Ty.SumTy aty b))
-conclude sig ctx (DElInj2Cong dB dA) = do
-  (b0, b1, bty) <- conclude sig ctx dB >>= needElEq
-  a <- conclude sig ctx dA >>= needTy
+conclude env sig ctx (DElInj2Cong dB dA) = do
+  (b0, b1, bty) <- conclude env sig ctx dB >>= needElEq
+  a <- conclude env sig ctx dA >>= needTy
   pure (JElEq (Inj2 b0) (Inj2 b1) (Ty.SumTy a bty))
-conclude sig ctx (DCodePiCong dA dB) = do
-  (a0, a1, aty) <- conclude sig ctx dA >>= needElEq
+conclude env sig ctx (DCodePiCong dA dB) = do
+  (a0, a1, aty) <- conclude env sig ctx dA >>= needElEq
   alphaTy "code-pi-cong" aty Ty.UniverseTy
-  (b0, b1, bty) <- conclude sig (ctx :< El a1) dB >>= needElEq
+  (b0, b1, bty) <- conclude env sig (ctx :< El a1) dB >>= needElEq
   alphaTy "code-pi-cong" bty Ty.UniverseTy
   pure (JElEq (Elem.PiTy a0 b0) (Elem.PiTy a1 b1) Ty.UniverseTy)
-conclude sig ctx (DCodeSigmaCong dA dB) = do
-  (a0, a1, aty) <- conclude sig ctx dA >>= needElEq
+conclude env sig ctx (DCodeSigmaCong dA dB) = do
+  (a0, a1, aty) <- conclude env sig ctx dA >>= needElEq
   alphaTy "code-sigma-cong" aty Ty.UniverseTy
-  (b0, b1, bty) <- conclude sig (ctx :< El a1) dB >>= needElEq
+  (b0, b1, bty) <- conclude env sig (ctx :< El a1) dB >>= needElEq
   alphaTy "code-sigma-cong" bty Ty.UniverseTy
   pure (JElEq (Elem.SigmaTy a0 b0) (Elem.SigmaTy a1 b1) Ty.UniverseTy)
-conclude sig ctx (DCodeSumCong dA dB) = do
-  (a0, a1, aty) <- conclude sig ctx dA >>= needElEq
+conclude env sig ctx (DCodeSumCong dA dB) = do
+  (a0, a1, aty) <- conclude env sig ctx dA >>= needElEq
   alphaTy "code-sum-cong" aty Ty.UniverseTy
-  (b0, b1, bty) <- conclude sig ctx dB >>= needElEq
+  (b0, b1, bty) <- conclude env sig ctx dB >>= needElEq
   alphaTy "code-sum-cong" bty Ty.UniverseTy
   pure (JElEq (Elem.SumTy a0 b0) (Elem.SumTy a1 b1) Ty.UniverseTy)
-conclude sig ctx (DCodeQuotCong dA dR) = do
-  (a0, a1, aty) <- conclude sig ctx dA >>= needElEq
+conclude env sig ctx (DCodeQuotCong dA dR) = do
+  (a0, a1, aty) <- conclude env sig ctx dA >>= needElEq
   alphaTy "code-quot-cong" aty Ty.UniverseTy
-  (r0, r1, rty) <- conclude sig (ctx :< El a1 :< wkTy (El a1)) dR >>= needElEq
+  (r0, r1, rty) <- conclude env sig (ctx :< El a1 :< wkTy (El a1)) dR >>= needElEq
   alphaTy "code-quot-cong" rty Ty.PropTy
   pure (JElEq (Elem.QuotTy a0 r0) (Elem.QuotTy a1 r1) Ty.UniverseTy)
-conclude sig ctx (DCodeSquashCong dA) = do
-  (a0, a1) <- conclude sig ctx dA >>= needTyEq
+conclude env sig ctx (DCodeSquashCong dA) = do
+  (a0, a1) <- conclude env sig ctx dA >>= needTyEq
   pure (JElEq (Squash a0) (Squash a1) Ty.PropTy)
-conclude sig ctx (DCodeEqCong dTy dA dB) = do
-  (t0, t1) <- conclude sig ctx dTy >>= needTyEq
-  (a0, a1, aty) <- conclude sig ctx dA >>= needElEq
+conclude env sig ctx (DCodeEqCong dTy dA dB) = do
+  (t0, t1) <- conclude env sig ctx dTy >>= needTyEq
+  (a0, a1, aty) <- conclude env sig ctx dA >>= needElEq
   alphaTy "code-eq-cong (a)" aty t1
-  (b0, b1, bty) <- conclude sig ctx dB >>= needElEq
+  (b0, b1, bty) <- conclude env sig ctx dB >>= needElEq
   alphaTy "code-eq-cong (b)" bty t1
   pure (JElEq (Elem.EqTy a0 b0 t0) (Elem.EqTy a1 b1 t1) Ty.PropTy)
 
 -- injectivity (grouped conclusions split)
-conclude sig ctx (DTyPiInjDom dB0 dB1 dEq) = do
-  (a0, a1, b0, b1) <- tyBinInj sig ctx "ty-pi-inj" piProj dB0 dB1 dEq
+conclude env sig ctx (DTyPiInjDom dB0 dB1 dEq) = do
+  (a0, a1, b0, b1) <- tyBinInj env sig ctx "ty-pi-inj" piProj dB0 dB1 dEq
   pure (JTyEq a0 a1)
-conclude sig ctx (DTyPiInjCod dB0 dB1 dEq) = do
-  (a0, a1, b0, b1) <- tyBinInj sig ctx "ty-pi-inj" piProj dB0 dB1 dEq
+conclude env sig ctx (DTyPiInjCod dB0 dB1 dEq) = do
+  (a0, a1, b0, b1) <- tyBinInj env sig ctx "ty-pi-inj" piProj dB0 dB1 dEq
   pure (JTyEq b0 b1)
-conclude sig ctx (DTySigmaInjDom dB0 dB1 dEq) = do
-  (a0, a1, b0, b1) <- tyBinInj sig ctx "ty-sigma-inj" sgProj dB0 dB1 dEq
+conclude env sig ctx (DTySigmaInjDom dB0 dB1 dEq) = do
+  (a0, a1, b0, b1) <- tyBinInj env sig ctx "ty-sigma-inj" sgProj dB0 dB1 dEq
   pure (JTyEq a0 a1)
-conclude sig ctx (DTySigmaInjCod dB0 dB1 dEq) = do
-  (a0, a1, b0, b1) <- tyBinInj sig ctx "ty-sigma-inj" sgProj dB0 dB1 dEq
+conclude env sig ctx (DTySigmaInjCod dB0 dB1 dEq) = do
+  (a0, a1, b0, b1) <- tyBinInj env sig ctx "ty-sigma-inj" sgProj dB0 dB1 dEq
   pure (JTyEq b0 b1)
-conclude sig ctx (DTySumInjL dEq) = do
-  (l, r) <- conclude sig ctx dEq >>= needTyEq
+conclude env sig ctx (DTySumInjL dEq) = do
+  (l, r) <- conclude env sig ctx dEq >>= needTyEq
   case (l, r) of
     (Ty.SumTy a0 _, Ty.SumTy a1 _) => pure (JTyEq a0 a1)
     _ => kerr "derivation: ty-sum-inj: not a ⊎ equation"
-conclude sig ctx (DTySumInjR dEq) = do
-  (l, r) <- conclude sig ctx dEq >>= needTyEq
+conclude env sig ctx (DTySumInjR dEq) = do
+  (l, r) <- conclude env sig ctx dEq >>= needTyEq
   case (l, r) of
     (Ty.SumTy _ b0, Ty.SumTy _ b1) => pure (JTyEq b0 b1)
     _ => kerr "derivation: ty-sum-inj: not a ⊎ equation"
-conclude sig ctx (DTyQuotInjDom dR0 dR1 dEq) = do
-  (a0, a1, r0, r1) <- tyQuotInj sig ctx dR0 dR1 dEq
+conclude env sig ctx (DTyQuotInjDom dR0 dR1 dEq) = do
+  (a0, a1, r0, r1) <- tyQuotInj env sig ctx dR0 dR1 dEq
   pure (JTyEq a0 a1)
-conclude sig ctx (DTyQuotInjRel dR0 dR1 dEq) = do
-  (a0, a1, r0, r1) <- tyQuotInj sig ctx dR0 dR1 dEq
+conclude env sig ctx (DTyQuotInjRel dR0 dR1 dEq) = do
+  (a0, a1, r0, r1) <- tyQuotInj env sig ctx dR0 dR1 dEq
   pure (JElEq r0 r1 Ty.PropTy)
-conclude sig ctx (DTyElInj dEq) = do
-  (l, r) <- conclude sig ctx dEq >>= needTyEq
+conclude env sig ctx (DTyElInj dEq) = do
+  (l, r) <- conclude env sig ctx dEq >>= needTyEq
   case (l, r) of
     (El t0, El t1) => pure (JElEq t0 t1 Ty.UniverseTy)
     _ => kerr "derivation: ty-el-inj: not an El equation"
-conclude sig ctx (DCodePiInjDom dB0 dB1 dEq) = do
-  (a0, a1, b0, b1) <- codeBinInj sig ctx "code-pi-inj" piCProj dB0 dB1 dEq
+conclude env sig ctx (DCodePiInjDom dB0 dB1 dEq) = do
+  (a0, a1, b0, b1) <- codeBinInj env sig ctx "code-pi-inj" piCProj dB0 dB1 dEq
   pure (JElEq a0 a1 Ty.UniverseTy)
-conclude sig ctx (DCodePiInjCod dB0 dB1 dEq) = do
-  (a0, a1, b0, b1) <- codeBinInj sig ctx "code-pi-inj" piCProj dB0 dB1 dEq
+conclude env sig ctx (DCodePiInjCod dB0 dB1 dEq) = do
+  (a0, a1, b0, b1) <- codeBinInj env sig ctx "code-pi-inj" piCProj dB0 dB1 dEq
   pure (JElEq b0 b1 Ty.UniverseTy)
-conclude sig ctx (DCodeSigmaInjDom dB0 dB1 dEq) = do
-  (a0, a1, b0, b1) <- codeBinInj sig ctx "code-sigma-inj" sgCProj dB0 dB1 dEq
+conclude env sig ctx (DCodeSigmaInjDom dB0 dB1 dEq) = do
+  (a0, a1, b0, b1) <- codeBinInj env sig ctx "code-sigma-inj" sgCProj dB0 dB1 dEq
   pure (JElEq a0 a1 Ty.UniverseTy)
-conclude sig ctx (DCodeSigmaInjCod dB0 dB1 dEq) = do
-  (a0, a1, b0, b1) <- codeBinInj sig ctx "code-sigma-inj" sgCProj dB0 dB1 dEq
+conclude env sig ctx (DCodeSigmaInjCod dB0 dB1 dEq) = do
+  (a0, a1, b0, b1) <- codeBinInj env sig ctx "code-sigma-inj" sgCProj dB0 dB1 dEq
   pure (JElEq b0 b1 Ty.UniverseTy)
-conclude sig ctx (DCodeSumInjL dEq) = do
-  (l, r, ty) <- conclude sig ctx dEq >>= needElEq
+conclude env sig ctx (DCodeSumInjL dEq) = do
+  (l, r, ty) <- conclude env sig ctx dEq >>= needElEq
   alphaTy "code-sum-inj" ty Ty.UniverseTy
   case (l, r) of
     (Elem.SumTy a0 _, Elem.SumTy a1 _) => pure (JElEq a0 a1 Ty.UniverseTy)
     _ => kerr "derivation: code-sum-inj: not a ⊎ code equation"
-conclude sig ctx (DCodeSumInjR dEq) = do
-  (l, r, ty) <- conclude sig ctx dEq >>= needElEq
+conclude env sig ctx (DCodeSumInjR dEq) = do
+  (l, r, ty) <- conclude env sig ctx dEq >>= needElEq
   alphaTy "code-sum-inj" ty Ty.UniverseTy
   case (l, r) of
     (Elem.SumTy _ b0, Elem.SumTy _ b1) => pure (JElEq b0 b1 Ty.UniverseTy)
     _ => kerr "derivation: code-sum-inj: not a ⊎ code equation"
-conclude sig ctx (DCodeQuotInjDom dR0 dR1 dEq) = do
-  (a0, a1, r0, r1) <- codeQuotInj sig ctx dR0 dR1 dEq
+conclude env sig ctx (DCodeQuotInjDom dR0 dR1 dEq) = do
+  (a0, a1, r0, r1) <- codeQuotInj env sig ctx dR0 dR1 dEq
   pure (JElEq a0 a1 Ty.UniverseTy)
-conclude sig ctx (DCodeQuotInjRel dR0 dR1 dEq) = do
-  (a0, a1, r0, r1) <- codeQuotInj sig ctx dR0 dR1 dEq
+conclude env sig ctx (DCodeQuotInjRel dR0 dR1 dEq) = do
+  (a0, a1, r0, r1) <- codeQuotInj env sig ctx dR0 dR1 dEq
   pure (JElEq r0 r1 Ty.PropTy)
 
 -- normal substitutions
-conclude sig ctx DSubNEmpty = pure (JSubN [<] [<])
-conclude sig ctx (DSubNExt dEs dA dE) = do
-  (es, delta) <- conclude sig ctx dEs >>= needSubN
-  a <- conclude sig delta dA >>= needTy
-  (e, ety) <- conclude sig ctx dE >>= needEl
+conclude env sig ctx DSubNEmpty = pure (JSubN [<] [<])
+conclude env sig ctx (DSubNExt dEs dA dE) = do
+  (es, delta) <- conclude env sig ctx dEs >>= needSubN
+  a <- conclude env sig delta dA >>= needTy
+  (e, ety) <- conclude env sig ctx dE >>= needEl
   alphaTy "sub-norm-ext" ety (substTy a (embed es))
   pure (JSubN (es :< e) (delta :< a))
 
 
 -- the remaining equivalence instances, ext-congruences, coercions
-conclude sig ctx (DCtxRefl d) = do
-  g <- conclude sig ctx d >>= needCtx
+conclude env sig ctx (DCtxRefl d) = do
+  g <- conclude env sig ctx d >>= needCtx
   pure (JCtxEq g g)
-conclude sig ctx (DCtxSym d) = do
-  (g0, g1) <- conclude sig ctx d >>= needCtxEq
+conclude env sig ctx (DCtxSym d) = do
+  (g0, g1) <- conclude env sig ctx d >>= needCtxEq
   pure (JCtxEq g1 g0)
-conclude sig ctx (DCtxTrans d01 d12) = do
-  (g0, g1) <- conclude sig ctx d01 >>= needCtxEq
-  (g1', g2) <- conclude sig ctx d12 >>= needCtxEq
+conclude env sig ctx (DCtxTrans d01 d12) = do
+  (g0, g1) <- conclude env sig ctx d01 >>= needCtxEq
+  (g1', g2) <- conclude env sig ctx d12 >>= needCtxEq
   if g1' == g1 then pure () else kerr "derivation: ctx-trans: middle mismatch"
   pure (JCtxEq g0 g2)
-conclude sig ctx (DCtxExtCong dG dA) = do
-  (g0, g1) <- conclude sig ctx dG >>= needCtxEq
-  (a0, a1) <- conclude sig g1 dA >>= needTyEq
+conclude env sig ctx (DCtxExtCong dG dA) = do
+  (g0, g1) <- conclude env sig ctx dG >>= needCtxEq
+  (a0, a1) <- conclude env sig g1 dA >>= needTyEq
   pure (JCtxEq (g0 :< a0) (g1 :< a1))
-conclude sig ctx (DSubRefl d) = do
-  (s', d') <- conclude sig ctx d >>= needSub
+conclude env sig ctx (DSubRefl d) = do
+  (s', d') <- conclude env sig ctx d >>= needSub
   pure (JSubEq s' s' d')
-conclude sig ctx (DSubSym d) = do
-  (s0, s1, d') <- conclude sig ctx d >>= needSubEq
+conclude env sig ctx (DSubSym d) = do
+  (s0, s1, d') <- conclude env sig ctx d >>= needSubEq
   pure (JSubEq s1 s0 d')
-conclude sig ctx (DSubTrans d01 d12) = do
-  (s0, s1, d') <- conclude sig ctx d01 >>= needSubEq
-  (s1', s2, d'') <- conclude sig ctx d12 >>= needSubEq
+conclude env sig ctx (DSubTrans d01 d12) = do
+  (s0, s1, d') <- conclude env sig ctx d01 >>= needSubEq
+  (s1', s2, d'') <- conclude env sig ctx d12 >>= needSubEq
   if s1' == s1 && d'' == d' then pure ()
     else kerr "derivation: sub-trans: middle mismatch"
   pure (JSubEq s0 s2 d')
-conclude sig ctx (DSubNRefl d) = do
-  (es, d') <- conclude sig ctx d >>= needSubN
+conclude env sig ctx (DSubNRefl d) = do
+  (es, d') <- conclude env sig ctx d >>= needSubN
   pure (JSubNEq es es d')
-conclude sig ctx (DSubNSym d) = do
-  (e0, e1, d') <- conclude sig ctx d >>= needSubNEq
+conclude env sig ctx (DSubNSym d) = do
+  (e0, e1, d') <- conclude env sig ctx d >>= needSubNEq
   pure (JSubNEq e1 e0 d')
-conclude sig ctx (DSubNTrans d01 d12) = do
-  (e0, e1, d') <- conclude sig ctx d01 >>= needSubNEq
-  (e1', e2, d'') <- conclude sig ctx d12 >>= needSubNEq
+conclude env sig ctx (DSubNTrans d01 d12) = do
+  (e0, e1, d') <- conclude env sig ctx d01 >>= needSubNEq
+  (e1', e2, d'') <- conclude env sig ctx d12 >>= needSubNEq
   if e1' == e1 && d'' == d' then pure ()
     else kerr "derivation: sub-norm (trans): middle mismatch"
   pure (JSubNEq e0 e2 d')
-conclude sig ctx (DSubNExtCong dEs dA dT) = do
-  (e0, e1, delta) <- conclude sig ctx dEs >>= needSubNEq
-  a <- conclude sig delta dA >>= needTy
-  (t0, t1, tty) <- conclude sig ctx dT >>= needElEq
+conclude env sig ctx (DSubNExtCong dEs dA dT) = do
+  (e0, e1, delta) <- conclude env sig ctx dEs >>= needSubNEq
+  a <- conclude env sig delta dA >>= needTy
+  (t0, t1, tty) <- conclude env sig ctx dT >>= needElEq
   alphaTy "sub-norm-ext-cong" tty (substTy a (embed e1))
   pure (JSubNEq (e0 :< t0) (e1 :< t1) (delta :< a))
-conclude sig ctx (DElSubCong dS dEq) = do
-  (s0, s1, g1) <- conclude sig ctx dS >>= needSubEq
-  (t0, t1, a) <- conclude sig g1 dEq >>= needElEq
+conclude env sig ctx (DElSubCong dS dEq) = do
+  (s0, s1, g1) <- conclude env sig ctx dS >>= needSubEq
+  (t0, t1, a) <- conclude env sig g1 dEq >>= needElEq
   pure (JElEq (substElem t0 s0) (substElem t1 s1) (substTy a s1))
-conclude sig ctx (DTySubCong dS dEq) = do
-  (s0, s1, g1) <- conclude sig ctx dS >>= needSubEq
-  (a0, a1) <- conclude sig g1 dEq >>= needTyEq
+conclude env sig ctx (DTySubCong dS dEq) = do
+  (s0, s1, g1) <- conclude env sig ctx dS >>= needSubEq
+  (a0, a1) <- conclude env sig g1 dEq >>= needTyEq
   pure (JTyEq (substTy a0 s0) (substTy a1 s1))
-conclude sig ctx DTelEmpty = pure (JTel [])
-conclude sig ctx (DTelExt dA dD) = do
-  a <- conclude sig ctx dA >>= needTy
-  d <- conclude sig (ctx :< a) dD >>= needTel
+conclude env sig ctx DTelEmpty = pure (JTel [])
+conclude env sig ctx (DTelExt dA dD) = do
+  a <- conclude env sig ctx dA >>= needTy
+  d <- conclude env sig (ctx :< a) dD >>= needTel
   pure (JTel (a :: d))
-conclude sig ctx (DTelExtCong dA dD) = do
-  (a0, a1) <- conclude sig ctx dA >>= needTyEq
-  (d0, d1) <- conclude sig (ctx :< a1) dD >>= needTelEq
+conclude env sig ctx (DTelExtCong dA dD) = do
+  (a0, a1) <- conclude env sig ctx dA >>= needTyEq
+  (d0, d1) <- conclude env sig (ctx :< a1) dD >>= needTelEq
   pure (JTelEq (a0 :: d0) (a1 :: d1))
-conclude sig ctx (DTelRefl d) = do
-  t <- conclude sig ctx d >>= needTel
+conclude env sig ctx (DTelRefl d) = do
+  t <- conclude env sig ctx d >>= needTel
   pure (JTelEq t t)
-conclude sig ctx (DTelSym d) = do
-  (d0, d1) <- conclude sig ctx d >>= needTelEq
+conclude env sig ctx (DTelSym d) = do
+  (d0, d1) <- conclude env sig ctx d >>= needTelEq
   pure (JTelEq d1 d0)
-conclude sig ctx (DTelTrans d01 d12) = do
-  (d0, d1) <- conclude sig ctx d01 >>= needTelEq
-  (d1', d2) <- conclude sig ctx d12 >>= needTelEq
+conclude env sig ctx (DTelTrans d01 d12) = do
+  (d0, d1) <- conclude env sig ctx d01 >>= needTelEq
+  (d1', d2) <- conclude env sig ctx d12 >>= needTelEq
   if d1' == d1 then pure () else kerr "derivation: tel-trans: middle mismatch"
   pure (JTelEq d0 d2)
-conclude sig ctx DSpEmpty = pure (JSp [] [])
-conclude sig ctx (DSpExt dE dD dEs) = do
-  (e, a) <- conclude sig ctx dE >>= needEl
-  d <- conclude sig (ctx :< a) dD >>= needTel
-  (es, dInst) <- conclude sig ctx dEs >>= needSp
+conclude env sig ctx DSpEmpty = pure (JSp [] [])
+conclude env sig ctx (DSpExt dE dD dEs) = do
+  (e, a) <- conclude env sig ctx dE >>= needEl
+  d <- conclude env sig (ctx :< a) dD >>= needTel
+  (es, dInst) <- conclude env sig ctx dEs >>= needSp
   if dInst == map (\t => substTy t (Ext Id e)) d then pure ()
     else kerr "derivation: sp-ext: tail not at the instantiated telescope"
   pure (JSp (e :: es) (a :: d))
-conclude sig ctx (DSpExtCong dE dD dEs) = do
-  (e0, e1, a) <- conclude sig ctx dE >>= needElEq
-  d <- conclude sig (ctx :< a) dD >>= needTel
-  (es0, es1, dInst) <- conclude sig ctx dEs >>= needSpEq
+conclude env sig ctx (DSpExtCong dE dD dEs) = do
+  (e0, e1, a) <- conclude env sig ctx dE >>= needElEq
+  d <- conclude env sig (ctx :< a) dD >>= needTel
+  (es0, es1, dInst) <- conclude env sig ctx dEs >>= needSpEq
   if dInst == map (\t => substTy t (Ext Id e1)) d then pure ()
     else kerr "derivation: sp-ext-cong: tails not at the instantiated telescope"
   pure (JSpEq (e0 :: es0) (e1 :: es1) (a :: d))
-conclude sig ctx (DSpRefl d) = do
-  (es, d') <- conclude sig ctx d >>= needSp
+conclude env sig ctx (DSpRefl d) = do
+  (es, d') <- conclude env sig ctx d >>= needSp
   pure (JSpEq es es d')
-conclude sig ctx (DSpSym d) = do
-  (e0, e1, d') <- conclude sig ctx d >>= needSpEq
+conclude env sig ctx (DSpSym d) = do
+  (e0, e1, d') <- conclude env sig ctx d >>= needSpEq
   pure (JSpEq e1 e0 d')
-conclude sig ctx (DSpTrans d01 d12) = do
-  (e0, e1, d') <- conclude sig ctx d01 >>= needSpEq
-  (e1', e2, d'') <- conclude sig ctx d12 >>= needSpEq
+conclude env sig ctx (DSpTrans d01 d12) = do
+  (e0, e1, d') <- conclude env sig ctx d01 >>= needSpEq
+  (e1', e2, d'') <- conclude env sig ctx d12 >>= needSpEq
   if e1' == e1 && d'' == d' then pure ()
     else kerr "derivation: sp-trans: middle mismatch"
   pure (JSpEq e0 e2 d')
-conclude sig ctx (DTyCoeCtx dG dA) = do
-  (g0, g1) <- conclude sig ctx dG >>= needCtxEq
+conclude env sig ctx (DTyCoeCtx dG dA) = do
+  (g0, g1) <- conclude env sig ctx dG >>= needCtxEq
   if ctx == g1 then pure ()
     else kerr "derivation: ty-coe-ctx: ambient is not the equation's right context"
-  a <- conclude sig g0 dA >>= needTy
+  a <- conclude env sig g0 dA >>= needTy
   pure (JTy a)
-conclude sig ctx (DElCoeCtx dG dA) = do
-  (g0, g1) <- conclude sig ctx dG >>= needCtxEq
+conclude env sig ctx (DElCoeCtx dG dA) = do
+  (g0, g1) <- conclude env sig ctx dG >>= needCtxEq
   if ctx == g1 then pure ()
     else kerr "derivation: el-coe-ctx: ambient is not the equation's right context"
-  (a, aty) <- conclude sig g0 dA >>= needEl
+  (a, aty) <- conclude env sig g0 dA >>= needEl
   pure (JEl a aty)
-conclude sig ctx (DTyEqCoeCtx dG dA) = do
-  (g0, g1) <- conclude sig ctx dG >>= needCtxEq
+conclude env sig ctx (DTyEqCoeCtx dG dA) = do
+  (g0, g1) <- conclude env sig ctx dG >>= needCtxEq
   if ctx == g1 then pure ()
     else kerr "derivation: ty-eq-coe-ctx: ambient is not the equation's right context"
-  (a0, a1) <- conclude sig g0 dA >>= needTyEq
+  (a0, a1) <- conclude env sig g0 dA >>= needTyEq
   pure (JTyEq a0 a1)
-conclude sig ctx (DElEqCoeCtx dG dA) = do
-  (g0, g1) <- conclude sig ctx dG >>= needCtxEq
+conclude env sig ctx (DElEqCoeCtx dG dA) = do
+  (g0, g1) <- conclude env sig ctx dG >>= needCtxEq
   if ctx == g1 then pure ()
     else kerr "derivation: el-eq-coe-ctx: ambient is not the equation's right context"
-  (t0, t1, a) <- conclude sig g0 dA >>= needElEq
+  (t0, t1, a) <- conclude env sig g0 dA >>= needElEq
   pure (JElEq t0 t1 a)
 
 -- ADMISSIBLE: presupposition projection
-conclude sig ctx (DPresupElL d) = do
-  (t0, _, a) <- conclude sig ctx d >>= needElEq
+conclude env sig ctx (DPresupElL d) = do
+  (t0, _, a) <- conclude env sig ctx d >>= needElEq
   pure (JEl t0 a)
-conclude sig ctx (DPresupElR d) = do
-  (_, t1, a) <- conclude sig ctx d >>= needElEq
+conclude env sig ctx (DPresupElR d) = do
+  (_, t1, a) <- conclude env sig ctx d >>= needElEq
   pure (JEl t1 a)
-conclude sig ctx (DPresupElTy d) = do
-  (_, a) <- conclude sig ctx d >>= needEl
+conclude env sig ctx (DPresupElTy d) = do
+  (_, a) <- conclude env sig ctx d >>= needEl
   pure (JTy a)
-conclude sig ctx (DPresupTyL d) = do
-  (a0, _) <- conclude sig ctx d >>= needTyEq
+conclude env sig ctx (DPresupTyL d) = do
+  (a0, _) <- conclude env sig ctx d >>= needTyEq
   pure (JTy a0)
-conclude sig ctx (DPresupTyR d) = do
-  (_, a1) <- conclude sig ctx d >>= needTyEq
+conclude env sig ctx (DPresupTyR d) = do
+  (_, a1) <- conclude env sig ctx d >>= needTyEq
   pure (JTy a1)
 
 -- ADMISSIBLE: formation inversion (docs/NovaDerivations.txt) — the
 -- cod instances replay their premise BELOW the top binder, which
 -- must α-match the inverted domain
-conclude sig ctx (DInvPiDom d) = do
-  t <- conclude sig ctx d >>= needTy
+conclude env sig ctx (DInvPiDom d) = do
+  t <- conclude env sig ctx d >>= needTy
   case t of
     Ty.PiTy a _ => pure (JTy a)
     _ => kerr "derivation: inv-pi-dom: premise not a Π formation"
-conclude sig ctx (DInvPiCod d) =
+conclude env sig ctx (DInvPiCod d) =
   case ctx of
     rest :< a' => do
-      t <- conclude sig rest d >>= needTy
+      t <- conclude env sig rest d >>= needTy
       case t of
         Ty.PiTy a b => do
           alphaTy "inv-pi-cod (binder)" a a'
           pure (JTy b)
         _ => kerr "derivation: inv-pi-cod: premise not a Π formation"
     [<] => kerr "derivation: inv-pi-cod: empty context"
-conclude sig ctx (DInvSigmaDom d) = do
-  t <- conclude sig ctx d >>= needTy
+conclude env sig ctx (DInvSigmaDom d) = do
+  t <- conclude env sig ctx d >>= needTy
   case t of
     Ty.SigmaTy a _ => pure (JTy a)
     _ => kerr "derivation: inv-sigma-dom: premise not a Σ formation"
-conclude sig ctx (DInvSigmaCod d) =
+conclude env sig ctx (DInvSigmaCod d) =
   case ctx of
     rest :< a' => do
-      t <- conclude sig rest d >>= needTy
+      t <- conclude env sig rest d >>= needTy
       case t of
         Ty.SigmaTy a b => do
           alphaTy "inv-sigma-cod (binder)" a a'
           pure (JTy b)
         _ => kerr "derivation: inv-sigma-cod: premise not a Σ formation"
     [<] => kerr "derivation: inv-sigma-cod: empty context"
-conclude sig ctx (DInvPrfEqL d) = do
-  t <- conclude sig ctx d >>= needTy
+conclude env sig ctx (DInvPrfEqL d) = do
+  t <- conclude env sig ctx d >>= needTy
   case t of
     Prf (Elem.EqTy a _ ty) => pure (JEl a ty)
     _ => kerr "derivation: inv-prf-eq-lhs: premise not a Prf-equality formation"
-conclude sig ctx (DInvPrfEqR d) = do
-  t <- conclude sig ctx d >>= needTy
+conclude env sig ctx (DInvPrfEqR d) = do
+  t <- conclude env sig ctx d >>= needTy
   case t of
     Prf (Elem.EqTy _ b ty) => pure (JEl b ty)
     _ => kerr "derivation: inv-prf-eq-rhs: premise not a Prf-equality formation"
-conclude sig ctx (DInvPrfEqTy d) = do
-  t <- conclude sig ctx d >>= needTy
+conclude env sig ctx (DInvPrfEqTy d) = do
+  t <- conclude env sig ctx d >>= needTy
   case t of
     Prf (Elem.EqTy _ _ ty) => pure (JTy ty)
     _ => kerr "derivation: inv-prf-eq-ty: premise not a Prf-equality formation"
-conclude sig ctx (DInvPrfCode d) = do
-  t <- conclude sig ctx d >>= needTy
+conclude env sig ctx (DInvPrfCode d) = do
+  t <- conclude env sig ctx d >>= needTy
   case t of
     Prf p => pure (JEl p Ty.PropTy)
     _ => kerr "derivation: inv-prf-code: premise not a Prf formation"
-conclude sig ctx (DInvElCode d) = do
-  t <- conclude sig ctx d >>= needTy
+conclude env sig ctx (DInvElCode d) = do
+  t <- conclude env sig ctx d >>= needTy
   case t of
     El a => pure (JEl a Ty.UniverseTy)
     _ => kerr "derivation: inv-el-code: premise not an El formation"
-conclude sig ctx (DInvCodeEqL d) = do
-  (c, cty) <- conclude sig ctx d >>= needEl
+conclude env sig ctx (DInvCodeEqL d) = do
+  (c, cty) <- conclude env sig ctx d >>= needEl
   alphaTy "inv-code-eq-lhs" cty Ty.PropTy
   case c of
     Elem.EqTy l _ t => pure (JEl l t)
     _ => kerr "derivation: inv-code-eq-lhs: premise not an equality code"
-conclude sig ctx (DInvCodeEqR d) = do
-  (c, cty) <- conclude sig ctx d >>= needEl
+conclude env sig ctx (DInvCodeEqR d) = do
+  (c, cty) <- conclude env sig ctx d >>= needEl
   alphaTy "inv-code-eq-rhs" cty Ty.PropTy
   case c of
     Elem.EqTy _ r t => pure (JEl r t)
     _ => kerr "derivation: inv-code-eq-rhs: premise not an equality code"
-conclude sig ctx (DInvCodeEqTy d) = do
-  (c, cty) <- conclude sig ctx d >>= needEl
+conclude env sig ctx (DInvCodeEqTy d) = do
+  (c, cty) <- conclude env sig ctx d >>= needEl
   alphaTy "inv-code-eq-ty" cty Ty.PropTy
   case c of
     Elem.EqTy _ _ t => pure (JTy t)
@@ -1710,38 +1725,53 @@ conclude sig ctx (DInvCodeEqTy d) = do
 -- path, demand a ≜ redex, contract (Nova.Kernel.Beta, one clause per
 -- ≜ rule); the conclusion's right side is COMPUTED, and its typing
 -- flows to consumers by presupposition
-conclude sig ctx (DBetaAt p d) = do
-  (t, a) <- conclude sig ctx d >>= needEl
+conclude env sig ctx (DBetaAt p d) = do
+  (t, a) <- conclude env sig ctx d >>= needEl
   case contractAtE sig p t of
     Just t' => pure (JElEq t t' a)
     Nothing => kerr "derivation: beta-at: no ≜ redex at the path"
-conclude sig ctx (DBetaAtTy p d) = do
-  a <- conclude sig ctx d >>= needTy
+conclude env sig ctx (DBetaAtTy p d) = do
+  a <- conclude env sig ctx d >>= needTy
   case contractAtT sig p a of
     Just a' => pure (JTyEq a a')
     Nothing => kerr "derivation: beta-at-ty: no ≜ redex at the path"
 
 -- ADMISSIBLE: the nf oracle (the typing premise is load-bearing —
 -- docs/NovaDerivations.txt)
-conclude sig ctx (DNfExpand d) = do
-  (t, a) <- conclude sig ctx d >>= needEl
+conclude env sig ctx (DNfExpand d) = do
+  (t, a) <- conclude env sig ctx d >>= needEl
   t' <- kElem sig t
   pure (JElEq t t' a)
-conclude sig ctx (DNfExpandTy d) = do
-  a <- conclude sig ctx d >>= needTy
+conclude env sig ctx (DNfExpandTy d) = do
+  a <- conclude env sig ctx d >>= needTy
   a' <- kTy sig a
   pure (JTyEq a a')
-conclude sig ctx (DNfEq d0 d1) = do
-  (t0, a) <- conclude sig ctx d0 >>= needEl
-  (t1, a') <- conclude sig ctx d1 >>= needEl
+conclude env sig ctx (DShare cx d body) = do
+  j <- conclude env sig cx d
+  conclude (env ++ [(cx, j)]) sig ctx body
+conclude env sig ctx (DRef i) =
+  case inBounds' i env of
+    Just (cx, j) =>
+      if cx == ctx
+        then pure j
+        else kerr "derivation: share-ref cited outside its binding context"
+    Nothing => kerr "derivation: share-ref out of range"
+ where
+  inBounds' : Nat -> List a -> Maybe a
+  inBounds' _ [] = Nothing
+  inBounds' Z (x :: _) = Just x
+  inBounds' (S n) (_ :: rest) = inBounds' n rest
+conclude env sig ctx (DNfEq d0 d1) = do
+  (t0, a) <- conclude env sig ctx d0 >>= needEl
+  (t1, a') <- conclude env sig ctx d1 >>= needEl
   alphaTy "nf-eq" a' a
   n0 <- kElem sig t0
   n1 <- kElem sig t1
   alphaEl "nf-eq" n0 n1
   pure (JElEq t0 t1 a)
-conclude sig ctx (DNfEqTy d0 d1) = do
-  a0 <- conclude sig ctx d0 >>= needTy
-  a1 <- conclude sig ctx d1 >>= needTy
+conclude env sig ctx (DNfEqTy d0 d1) = do
+  a0 <- conclude env sig ctx d0 >>= needTy
+  a1 <- conclude env sig ctx d1 >>= needTy
   n0 <- kTy sig a0
   n1 <- kTy sig a1
   alphaTy "nf-eq-ty" n0 n1
@@ -1749,50 +1779,50 @@ conclude sig ctx (DNfEqTy d0 d1) = do
 
 
 -- quotients
-conclude sig ctx (DElQuotI dA dR) = do
-  (a, aty) <- conclude sig ctx dA >>= needEl
-  (r, rty) <- conclude sig (ctx :< aty :< wkTy aty) dR >>= needEl
+conclude env sig ctx (DElQuotI dA dR) = do
+  (a, aty) <- conclude env sig ctx dA >>= needEl
+  (r, rty) <- conclude env sig (ctx :< aty :< wkTy aty) dR >>= needEl
   alphaTy "el-quot-i" rty Ty.PropTy
   pure (JEl (Class a) (Ty.Quotient aty r))
-conclude sig ctx (DElQuotEq dA dB dR dW) = do
-  (a, aty) <- conclude sig ctx dA >>= needEl
-  (b, bty) <- conclude sig ctx dB >>= needEl
+conclude env sig ctx (DElQuotEq dA dB dR dW) = do
+  (a, aty) <- conclude env sig ctx dA >>= needEl
+  (b, bty) <- conclude env sig ctx dB >>= needEl
   alphaTy "el-quot-eq" bty aty
-  (r, rty) <- conclude sig (ctx :< aty :< wkTy aty) dR >>= needEl
+  (r, rty) <- conclude env sig (ctx :< aty :< wkTy aty) dR >>= needEl
   alphaTy "el-quot-eq" rty Ty.PropTy
-  (_, wty) <- conclude sig ctx dW >>= needEl
+  (_, wty) <- conclude env sig ctx dW >>= needEl
   alphaTy "el-quot-eq (witness)" wty
     (Prf (substElem r (Ext (Ext Id a) b)))
   pure (JElEq (Class a) (Class b) (Ty.Quotient aty r))
-conclude sig ctx (DElQuotE dQ dB dF dResp) = do
-  (q, qty) <- conclude sig ctx dQ >>= needEl
+conclude env sig ctx (DElQuotE dQ dB dF dResp) = do
+  (q, qty) <- conclude env sig ctx dQ >>= needEl
   case qty of
     Ty.Quotient a r => do
-      b <- conclude sig (ctx :< Ty.Quotient a r) dB >>= needTy
-      (f, fty) <- conclude sig (ctx :< a) dF >>= needEl
+      b <- conclude env sig (ctx :< Ty.Quotient a r) dB >>= needTy
+      (f, fty) <- conclude env sig (ctx :< a) dF >>= needEl
       alphaTy "el-quot-e (case)" fty (substTy b (Ext Wk (Class (CtxVar 0))))
       let wk3 = Chain Wk (Chain Wk Wk)
-      (l, r', ety) <- conclude sig (ctx :< a :< wkTy a :< Prf r) dResp >>= needElEq
+      (l, r', ety) <- conclude env sig (ctx :< a :< wkTy a :< Prf r) dResp >>= needElEq
       alphaEl "el-quot-e (wd l)" l (substElem f (Ext wk3 (CtxVar 2)))
       alphaEl "el-quot-e (wd r)" r' (substElem f (Ext wk3 (CtxVar 1)))
       alphaTy "el-quot-e (wd ty)" ety (substTy b (Ext wk3 (Class (CtxVar 2))))
       pure (JEl (QuotElim f q) (substTy b (Ext Id q)))
     _ => kerr "derivation: el-quot-e: scrutinee not at a quotient type"
-conclude sig ctx (DElQuotEta dQ dB dG dF dResp dAg) = do
-  (q, qty) <- conclude sig ctx dQ >>= needEl
+conclude env sig ctx (DElQuotEta dQ dB dG dF dResp dAg) = do
+  (q, qty) <- conclude env sig ctx dQ >>= needEl
   case qty of
     Ty.Quotient a r => do
-      b <- conclude sig (ctx :< Ty.Quotient a r) dB >>= needTy
-      (g, gty) <- conclude sig (ctx :< Ty.Quotient a r) dG >>= needEl
+      b <- conclude env sig (ctx :< Ty.Quotient a r) dB >>= needTy
+      (g, gty) <- conclude env sig (ctx :< Ty.Quotient a r) dG >>= needEl
       alphaTy "el-quot-eta (g)" gty b
-      (f, fty) <- conclude sig (ctx :< a) dF >>= needEl
+      (f, fty) <- conclude env sig (ctx :< a) dF >>= needEl
       alphaTy "el-quot-eta (f)" fty (substTy b (Ext Wk (Class (CtxVar 0))))
       let wk3 = Chain Wk (Chain Wk Wk)
-      (l, r', ety) <- conclude sig (ctx :< a :< wkTy a :< Prf r) dResp >>= needElEq
+      (l, r', ety) <- conclude env sig (ctx :< a :< wkTy a :< Prf r) dResp >>= needElEq
       alphaEl "el-quot-eta (wd l)" l (substElem f (Ext wk3 (CtxVar 2)))
       alphaEl "el-quot-eta (wd r)" r' (substElem f (Ext wk3 (CtxVar 1)))
       alphaTy "el-quot-eta (wd ty)" ety (substTy b (Ext wk3 (Class (CtxVar 2))))
-      (gl, gr, aty') <- conclude sig (ctx :< a) dAg >>= needElEq
+      (gl, gr, aty') <- conclude env sig (ctx :< a) dAg >>= needElEq
       alphaEl "el-quot-eta (ag l)" gl (substElem g (Ext Wk (Class (CtxVar 0))))
       alphaEl "el-quot-eta (ag r)" gr f
       alphaTy "el-quot-eta (ag ty)" aty' (substTy b (Ext Wk (Class (CtxVar 0))))
@@ -1800,52 +1830,52 @@ conclude sig ctx (DElQuotEta dQ dB dG dF dResp dAg) = do
     _ => kerr "derivation: el-quot-eta: scrutinee not at a quotient type"
 
 -- the remaining η rules
-conclude sig ctx (DElNatEta dMot dF0 dF1 dZ dS dEqZ dEqS0 dEqS1 dT) = do
-  mot <- conclude sig (ctx :< Ty.NatTy) dMot >>= needTy
-  (f0, f0ty) <- conclude sig (ctx :< Ty.NatTy) dF0 >>= needEl
+conclude env sig ctx (DElNatEta dMot dF0 dF1 dZ dS dEqZ dEqS0 dEqS1 dT) = do
+  mot <- conclude env sig (ctx :< Ty.NatTy) dMot >>= needTy
+  (f0, f0ty) <- conclude env sig (ctx :< Ty.NatTy) dF0 >>= needEl
   alphaTy "el-nat-eta (f₀)" f0ty mot
-  (f1, f1ty) <- conclude sig (ctx :< Ty.NatTy) dF1 >>= needEl
+  (f1, f1ty) <- conclude env sig (ctx :< Ty.NatTy) dF1 >>= needEl
   alphaTy "el-nat-eta (f₁)" f1ty mot
-  (z, zty) <- conclude sig ctx dZ >>= needEl
+  (z, zty) <- conclude env sig ctx dZ >>= needEl
   alphaTy "el-nat-eta (z)" zty (substTy mot (Ext Id NatIntro0))
-  (s, sty) <- conclude sig (ctx :< Ty.NatTy :< mot) dS >>= needEl
+  (s, sty) <- conclude env sig (ctx :< Ty.NatTy :< mot) dS >>= needEl
   alphaTy "el-nat-eta (s)" sty
     (substTy mot (Chain (Ext Wk (NatIntro1 (CtxVar 0))) Wk))
-  (zl, zr, zety) <- conclude sig ctx dEqZ >>= needElEq
+  (zl, zr, zety) <- conclude env sig ctx dEqZ >>= needElEq
   alphaEl "el-nat-eta (Z l)" zl (substElem f0 (Ext Id NatIntro0))
   alphaEl "el-nat-eta (Z r)" zr (substElem f1 (Ext Id NatIntro0))
   alphaTy "el-nat-eta (Z ty)" zety (substTy mot (Ext Id NatIntro0))
   let sSub = Ext Wk (NatIntro1 (CtxVar 0))
-  (s0l, s0r, s0ty) <- conclude sig (ctx :< Ty.NatTy) dEqS0 >>= needElEq
+  (s0l, s0r, s0ty) <- conclude env sig (ctx :< Ty.NatTy) dEqS0 >>= needElEq
   alphaEl "el-nat-eta (S₀ l)" s0l (substElem f0 sSub)
   alphaEl "el-nat-eta (S₀ r)" s0r (substElem s (Ext Id f0))
   alphaTy "el-nat-eta (S₀ ty)" s0ty (substTy mot sSub)
-  (s1l, s1r, s1ty) <- conclude sig (ctx :< Ty.NatTy) dEqS1 >>= needElEq
+  (s1l, s1r, s1ty) <- conclude env sig (ctx :< Ty.NatTy) dEqS1 >>= needElEq
   alphaEl "el-nat-eta (S₁ l)" s1l (substElem f1 sSub)
   alphaEl "el-nat-eta (S₁ r)" s1r (substElem s (Ext Id f1))
   alphaTy "el-nat-eta (S₁ ty)" s1ty (substTy mot sSub)
-  (t, tty) <- conclude sig ctx dT >>= needEl
+  (t, tty) <- conclude env sig ctx dT >>= needEl
   alphaTy "el-nat-eta (t)" tty Ty.NatTy
   pure (JElEq (substElem f0 (Ext Id t)) (substElem f1 (Ext Id t))
               (substTy mot (Ext Id t)))
-conclude sig ctx (DElSumEta dT dC dG dL dR dAgL dAgR) = do
-  (t, tty) <- conclude sig ctx dT >>= needEl
+conclude env sig ctx (DElSumEta dT dC dG dL dR dAgL dAgR) = do
+  (t, tty) <- conclude env sig ctx dT >>= needEl
   case tty of
     Ty.SumTy a b => do
-      c <- conclude sig (ctx :< Ty.SumTy a b) dC >>= needTy
-      (g, gty) <- conclude sig (ctx :< Ty.SumTy a b) dG >>= needEl
+      c <- conclude env sig (ctx :< Ty.SumTy a b) dC >>= needTy
+      (g, gty) <- conclude env sig (ctx :< Ty.SumTy a b) dG >>= needEl
       alphaTy "el-sum-eta (g)" gty c
       let lSub = Ext Wk (Inj1 (CtxVar 0))
       let rSub = Ext Wk (Inj2 (CtxVar 0))
-      (l, lty) <- conclude sig (ctx :< a) dL >>= needEl
+      (l, lty) <- conclude env sig (ctx :< a) dL >>= needEl
       alphaTy "el-sum-eta (l)" lty (substTy c lSub)
-      (r, rty) <- conclude sig (ctx :< b) dR >>= needEl
+      (r, rty) <- conclude env sig (ctx :< b) dR >>= needEl
       alphaTy "el-sum-eta (r)" rty (substTy c rSub)
-      (all', alr, alty) <- conclude sig (ctx :< a) dAgL >>= needElEq
+      (all', alr, alty) <- conclude env sig (ctx :< a) dAgL >>= needElEq
       alphaEl "el-sum-eta (agl l)" all' (substElem g lSub)
       alphaEl "el-sum-eta (agl r)" alr l
       alphaTy "el-sum-eta (agl ty)" alty (substTy c lSub)
-      (arl, arr, arty) <- conclude sig (ctx :< b) dAgR >>= needElEq
+      (arl, arr, arty) <- conclude env sig (ctx :< b) dAgR >>= needElEq
       alphaEl "el-sum-eta (agr l)" arl (substElem g rSub)
       alphaEl "el-sum-eta (agr r)" arr r
       alphaTy "el-sum-eta (agr ty)" arty (substTy c rSub)
@@ -1853,132 +1883,132 @@ conclude sig ctx (DElSumEta dT dC dG dL dR dAgL dAgR) = do
     _ => kerr "derivation: el-sum-eta: scrutinee not at a ⊎ type"
 
 -- contexts and substitutions
-conclude sig ctx DCtxEmpty = pure (JCtx [<])
-conclude sig ctx (DCtxExt dG dA) = do
-  g <- conclude sig ctx dG >>= needCtx
-  a <- conclude sig g dA >>= needTy
+conclude env sig ctx DCtxEmpty = pure (JCtx [<])
+conclude env sig ctx (DCtxExt dG dA) = do
+  g <- conclude env sig ctx dG >>= needCtx
+  a <- conclude env sig g dA >>= needTy
   pure (JCtx (g :< a))
-conclude sig ctx DSubEmpty = pure (JSub Terminal [<])
-conclude sig ctx DSubId = pure (JSub Id ctx)
-conclude sig ctx DSubWk =
+conclude env sig ctx DSubEmpty = pure (JSub Terminal [<])
+conclude env sig ctx DSubId = pure (JSub Id ctx)
+conclude env sig ctx DSubWk =
   case ctx of
     (rest :< _) => pure (JSub Wk rest)
     [<] => kerr "derivation: sub-wk: the ambient context is empty"
-conclude sig ctx (DSubExt dS dA dT) = do
-  (s, g1) <- conclude sig ctx dS >>= needSub
-  a <- conclude sig g1 dA >>= needTy
-  (t, tty) <- conclude sig ctx dT >>= needEl
+conclude env sig ctx (DSubExt dS dA dT) = do
+  (s, g1) <- conclude env sig ctx dS >>= needSub
+  a <- conclude env sig g1 dA >>= needTy
+  (t, tty) <- conclude env sig ctx dT >>= needEl
   alphaTy "sub-ext" tty (substTy a s)
   pure (JSub (Ext s t) (g1 :< a))
-conclude sig ctx (DSubComp dS dT) = do
-  (s, g1) <- conclude sig ctx dS >>= needSub
-  (t, g2) <- conclude sig g1 dT >>= needSub
+conclude env sig ctx (DSubComp dS dT) = do
+  (s, g1) <- conclude env sig ctx dS >>= needSub
+  (t, g2) <- conclude env sig g1 dT >>= needSub
   pure (JSub (Chain t s) g2)
-conclude sig ctx (DSubExtCong dS dA dT) = do
-  (s0, s1, g1) <- conclude sig ctx dS >>= needSubEq
-  a <- conclude sig g1 dA >>= needTy
-  (t0, t1, tty) <- conclude sig ctx dT >>= needElEq
+conclude env sig ctx (DSubExtCong dS dA dT) = do
+  (s0, s1, g1) <- conclude env sig ctx dS >>= needSubEq
+  a <- conclude env sig g1 dA >>= needTy
+  (t0, t1, tty) <- conclude env sig ctx dT >>= needElEq
   alphaTy "sub-ext-cong" tty (substTy a s1)
   pure (JSubEq (Ext s0 t0) (Ext s1 t1) (g1 :< a))
-conclude sig ctx (DElSubCongFix dS dEq) = do
-  (s, g1) <- conclude sig ctx dS >>= needSub
-  (t0, t1, a) <- conclude sig g1 dEq >>= needElEq
+conclude env sig ctx (DElSubCongFix dS dEq) = do
+  (s, g1) <- conclude env sig ctx dS >>= needSub
+  (t0, t1, a) <- conclude env sig g1 dEq >>= needElEq
   pure (JElEq (substElem t0 s) (substElem t1 s) (substTy a s))
-conclude sig ctx (DTySubCongFix dS dEq) = do
-  (s, g1) <- conclude sig ctx dS >>= needSub
-  (a0, a1) <- conclude sig g1 dEq >>= needTyEq
+conclude env sig ctx (DTySubCongFix dS dEq) = do
+  (s, g1) <- conclude env sig ctx dS >>= needSub
+  (a0, a1) <- conclude env sig g1 dEq >>= needTyEq
   pure (JTyEq (substTy a0 s) (substTy a1 s))
 
 -- the ν layer
-conclude sig ctx DPolyHole = pure (JPoly PHole)
-conclude sig ctx (DPolyConst dA) = do
-  (a, aty) <- conclude sig ctx dA >>= needEl
+conclude env sig ctx DPolyHole = pure (JPoly PHole)
+conclude env sig ctx (DPolyConst dA) = do
+  (a, aty) <- conclude env sig ctx dA >>= needEl
   alphaTy "poly-const" aty Ty.UniverseTy
   pure (JPoly (PConst a))
-conclude sig ctx (DPolyProd dF dG) = do
-  f <- conclude sig ctx dF >>= needPoly
-  g <- conclude sig ctx dG >>= needPoly
+conclude env sig ctx (DPolyProd dF dG) = do
+  f <- conclude env sig ctx dF >>= needPoly
+  g <- conclude env sig ctx dG >>= needPoly
   pure (JPoly (PProd f g))
-conclude sig ctx (DPolySum dF dG) = do
-  f <- conclude sig ctx dF >>= needPoly
-  g <- conclude sig ctx dG >>= needPoly
+conclude env sig ctx (DPolySum dF dG) = do
+  f <- conclude env sig ctx dF >>= needPoly
+  g <- conclude env sig ctx dG >>= needPoly
   pure (JPoly (PSum f g))
-conclude sig ctx (DPolySigma dA dF) = do
-  (a, aty) <- conclude sig ctx dA >>= needEl
+conclude env sig ctx (DPolySigma dA dF) = do
+  (a, aty) <- conclude env sig ctx dA >>= needEl
   alphaTy "poly-sigma" aty Ty.UniverseTy
-  f <- conclude sig (ctx :< El a) dF >>= needPoly
+  f <- conclude env sig (ctx :< El a) dF >>= needPoly
   pure (JPoly (PSigma a f))
-conclude sig ctx (DPolyPi dA dF) = do
-  (a, aty) <- conclude sig ctx dA >>= needEl
+conclude env sig ctx (DPolyPi dA dF) = do
+  (a, aty) <- conclude env sig ctx dA >>= needEl
   alphaTy "poly-pi" aty Ty.UniverseTy
-  f <- conclude sig (ctx :< El a) dF >>= needPoly
+  f <- conclude env sig (ctx :< El a) dF >>= needPoly
   pure (JPoly (PPi a f))
-conclude sig ctx (DTyNu dF) = do
-  f <- conclude sig ctx dF >>= needPoly
+conclude env sig ctx (DTyNu dF) = do
+  f <- conclude env sig ctx dF >>= needPoly
   pure (JTy (Ty.NuTy f))
-conclude sig ctx (DCodeNu dF) = do
-  f <- conclude sig ctx dF >>= needPoly
+conclude env sig ctx (DCodeNu dF) = do
+  f <- conclude env sig ctx dF >>= needPoly
   pure (JEl (Elem.NuTy f) Ty.UniverseTy)
-conclude sig ctx (DElNuE dF dT) = do
-  f <- conclude sig ctx dF >>= needPoly
-  (t, tty) <- conclude sig ctx dT >>= needEl
+conclude env sig ctx (DElNuE dF dT) = do
+  f <- conclude env sig ctx dF >>= needPoly
+  (t, tty) <- conclude env sig ctx dT >>= needEl
   alphaTy "el-nu-e" tty (Ty.NuTy f)
   pure (JEl (Out t) (El (reflectPoly f (Elem.NuTy f))))
-conclude sig ctx (DElNuI dF dA dBody dX) = do
-  f <- conclude sig ctx dF >>= needPoly
-  (a, aty) <- conclude sig ctx dA >>= needEl
+conclude env sig ctx (DElNuI dF dA dBody dX) = do
+  f <- conclude env sig ctx dF >>= needPoly
+  (a, aty) <- conclude env sig ctx dA >>= needEl
   alphaTy "el-nu-i (carrier)" aty Ty.UniverseTy
-  (body, bty) <- conclude sig (ctx :< El a) dBody >>= needEl
+  (body, bty) <- conclude env sig (ctx :< El a) dBody >>= needEl
   alphaTy "el-nu-i (coalgebra)" bty (wkTy (El (reflectPoly f a)))
-  (x, xty) <- conclude sig ctx dX >>= needEl
+  (x, xty) <- conclude env sig ctx dX >>= needEl
   alphaTy "el-nu-i (seed)" xty (El a)
   pure (JEl (Corec f a body x) (Ty.NuTy f))
-conclude sig ctx (DElNuCoind dF dT0 dT1 dR dP dQ) = do
-  f <- conclude sig ctx dF >>= needPoly
+conclude env sig ctx (DElNuCoind dF dT0 dT1 dR dP dQ) = do
+  f <- conclude env sig ctx dF >>= needPoly
   let nuT = Ty.NuTy f
-  (t0, t0ty) <- conclude sig ctx dT0 >>= needEl
+  (t0, t0ty) <- conclude env sig ctx dT0 >>= needEl
   alphaTy "el-nu-coind (t₀)" t0ty nuT
-  (t1, t1ty) <- conclude sig ctx dT1 >>= needEl
+  (t1, t1ty) <- conclude env sig ctx dT1 >>= needEl
   alphaTy "el-nu-coind (t₁)" t1ty nuT
-  (r, rty) <- conclude sig (ctx :< nuT :< substTy nuT Wk) dR >>= needEl
+  (r, rty) <- conclude env sig (ctx :< nuT :< substTy nuT Wk) dR >>= needEl
   alphaTy "el-nu-coind (R)" rty Ty.PropTy
-  (_, pty) <- conclude sig ctx dP >>= needEl
+  (_, pty) <- conclude env sig ctx dP >>= needEl
   alphaTy "el-nu-coind (endpoint)" pty
     (Prf (substElem r (Ext (Ext Id t0) t1)))
   let wk3 = Chain Wk (Chain Wk Wk)
-  (_, qty) <- conclude sig (ctx :< nuT :< substTy nuT Wk :< Prf r) dQ >>= needEl
+  (_, qty) <- conclude env sig (ctx :< nuT :< substTy nuT Wk :< Prf r) dQ >>= needEl
   alphaTy "el-nu-coind (closure)" qty
     (Prf (liftPoly (substPoly f wk3) (substElem r (under (under wk3)))
             (Out (CtxVar 2)) (Out (CtxVar 1))))
   pure (JElEq t0 t1 nuT)
 
 -- the ToS layer
-conclude sig ctx DQCtxEmpty = pure (JQCtx [<])
-conclude sig ctx (DQCtxExt dPhi dA) = do
-  phi <- conclude sig ctx dPhi >>= needQCtx
-  a <- concludeQTy sig ctx phi dA
+conclude env sig ctx DQCtxEmpty = pure (JQCtx [<])
+conclude env sig ctx (DQCtxExt dPhi dA) = do
+  phi <- conclude env sig ctx dPhi >>= needQCtx
+  a <- concludeQTy env sig ctx phi dA
   pure (JQCtx (phi :< a))
-conclude sig ctx (DQSig dPhi) = do
-  phi <- conclude sig ctx dPhi >>= needQCtx
+conclude env sig ctx (DQSig dPhi) = do
+  phi <- conclude env sig ctx dPhi >>= needQCtx
   pure (JQSig (toList phi))
-conclude sig ctx d@DQTyUniv = kerr "derivation: qty node outside the Γ;Φ zone"
-conclude sig ctx d@(DQTyEl _) = kerr "derivation: qty node outside the Γ;Φ zone"
-conclude sig ctx d@(DQTyPiExt _ _) = kerr "derivation: qty node outside the Γ;Φ zone"
-conclude sig ctx d@(DQTyPiInd _ _) = kerr "derivation: qty node outside the Γ;Φ zone"
-conclude sig ctx d@(DQTmVar _) = kerr "derivation: qtm node outside the Γ;Φ zone"
-conclude sig ctx d@(DQTmAppExt _ _) = kerr "derivation: qtm node outside the Γ;Φ zone"
-conclude sig ctx d@(DQTmAppInd _ _) = kerr "derivation: qtm node outside the Γ;Φ zone"
-conclude sig ctx d@(DQTmEq _ _) = kerr "derivation: qtm node outside the Γ;Φ zone"
-conclude sig ctx d@(DQTmSub _ _) = kerr "derivation: qtm node outside the Γ;Φ zone"
-conclude sig ctx d@DQSubId = kerr "derivation: qsub node outside the Γ;Φ zone"
-conclude sig ctx d@DQSubWk = kerr "derivation: qsub node outside the Γ;Φ zone"
-conclude sig ctx d@(DQSubComp _ _) = kerr "derivation: qsub node outside the Γ;Φ zone"
-conclude sig ctx d@(DQSubExt _ _ _) = kerr "derivation: qsub node outside the Γ;Φ zone"
-conclude sig ctx d@(DQTySub _ _) = kerr "derivation: qty node outside the Γ;Φ zone"
+conclude env sig ctx d@DQTyUniv = kerr "derivation: qty node outside the Γ;Φ zone"
+conclude env sig ctx d@(DQTyEl _) = kerr "derivation: qty node outside the Γ;Φ zone"
+conclude env sig ctx d@(DQTyPiExt _ _) = kerr "derivation: qty node outside the Γ;Φ zone"
+conclude env sig ctx d@(DQTyPiInd _ _) = kerr "derivation: qty node outside the Γ;Φ zone"
+conclude env sig ctx d@(DQTmVar _) = kerr "derivation: qtm node outside the Γ;Φ zone"
+conclude env sig ctx d@(DQTmAppExt _ _) = kerr "derivation: qtm node outside the Γ;Φ zone"
+conclude env sig ctx d@(DQTmAppInd _ _) = kerr "derivation: qtm node outside the Γ;Φ zone"
+conclude env sig ctx d@(DQTmEq _ _) = kerr "derivation: qtm node outside the Γ;Φ zone"
+conclude env sig ctx d@(DQTmSub _ _) = kerr "derivation: qtm node outside the Γ;Φ zone"
+conclude env sig ctx d@DQSubId = kerr "derivation: qsub node outside the Γ;Φ zone"
+conclude env sig ctx d@DQSubWk = kerr "derivation: qsub node outside the Γ;Φ zone"
+conclude env sig ctx d@(DQSubComp _ _) = kerr "derivation: qsub node outside the Γ;Φ zone"
+conclude env sig ctx d@(DQSubExt _ _ _) = kerr "derivation: qsub node outside the Γ;Φ zone"
+conclude env sig ctx d@(DQTySub _ _) = kerr "derivation: qty node outside the Γ;Φ zone"
 
 -- the QIIT item layer
-conclude sig ctx (DCodeQSortInjIdx i d) = do
-  (c0, c1, ty) <- conclude sig ctx d >>= needElEq
+conclude env sig ctx (DCodeQSortInjIdx i d) = do
+  (c0, c1, ty) <- conclude env sig ctx d >>= needElEq
   alphaTy "code-qsort-inj-idx (universe)" ty Ty.UniverseTy
   case (c0, c1) of
     (QSortC sg0 k0 es0, QSortC sg1 k1 es1) => do
@@ -1993,15 +2023,15 @@ conclude sig ctx (DCodeQSortInjIdx i d) = do
         (Just a0, Just a1, Just e) => pure (JElEq a0 a1 e)
         _ => kerr "derivation: code-qsort-inj-idx: index out of range"
     _ => kerr "derivation: code-qsort-inj-idx: premise not between sort codes"
-conclude sig ctx (DTyQSort k dSig ds) = do
-  sg <- conclude sig ctx dSig >>= needQSig
+conclude env sig ctx (DTyQSort k dSig ds) = do
+  sg <- conclude env sig ctx dSig >>= needQSig
   (entry, tel) <- qArity sg k
-  es <- qSpine "ty-qiit" sig ctx ds tel
+  es <- qSpine env "ty-qiit" sig ctx ds tel
   pure (JTy (QSort sg k (cast es)))
-conclude sig ctx (DTyQSortCong k dSig ds) = do
-  sg <- conclude sig ctx dSig >>= needQSig
+conclude env sig ctx (DTyQSortCong k dSig ds) = do
+  sg <- conclude env sig ctx dSig >>= needQSig
   (_, tel) <- qArity sg k
-  triples <- traverse (\d => conclude sig ctx d >>= needElEq) ds
+  triples <- traverse (\d => conclude env sig ctx d >>= needElEq) ds
   let es0 = map (\(a, _, _) => a) triples
   let es1 = map (\(_, b, _) => b) triples
   if length es0 == length tel then pure ()
@@ -2016,15 +2046,15 @@ conclude sig ctx (DTyQSortCong k dSig ds) = do
       Just want => alphaTy "ty-qiit-cong" ety want
       Nothing => kerr "derivation: ty-qiit-cong: telescope instantiation failed"
     goChk tel (S i) rest es0
-conclude sig ctx (DCodeQSort k dSig ds) = do
-  sg <- conclude sig ctx dSig >>= needQSig
+conclude env sig ctx (DCodeQSort k dSig ds) = do
+  sg <- conclude env sig ctx dSig >>= needQSig
   if qSigSmall sg then pure ()
     else kerr "derivation: code-qiit: signature not small"
   (entry, tel) <- qArity sg k
-  es <- qSpine "code-qiit" sig ctx ds tel
+  es <- qSpine env "code-qiit" sig ctx ds tel
   pure (JEl (QSortC sg k (cast es)) Ty.UniverseTy)
-conclude sig ctx (DQCtor k dSig ds) = do
-  sg <- conclude sig ctx dSig >>= needQSig
+conclude env sig ctx (DQCtor k dSig ds) = do
+  sg <- conclude env sig ctx dSig >>= needQSig
   entry <- case qEntry sg k of
              Just e => pure e
              Nothing => kerr "derivation: el-qiit-intro: position out of range"
@@ -2032,12 +2062,12 @@ conclude sig ctx (DQCtor k dSig ds) = do
     QKPoint => pure ()
     _ => kerr "derivation: el-qiit-intro: not a point constructor"
   (tel, _, _) <- liftQE (reflTel sg (qwAt k) entry)
-  es <- qSpine "el-qiit-intro" sig ctx ds tel
+  es <- qSpine env "el-qiit-intro" sig ctx ds tel
   (wEnd, hd) <- liftQE (walkVals sg (qwAt k) entry es)
   (srt, idx) <- liftQE (pointHead sg wEnd hd)
   pure (JEl (QCtor sg k (cast es)) (QSort sg srt idx))
-conclude sig ctx (DQCtorCong k dSig ds) = do
-  sg <- conclude sig ctx dSig >>= needQSig
+conclude env sig ctx (DQCtorCong k dSig ds) = do
+  sg <- conclude env sig ctx dSig >>= needQSig
   entry <- case qEntry sg k of
              Just e => pure e
              Nothing => kerr "derivation: el-qiit-intro-cong: position out of range"
@@ -2045,7 +2075,7 @@ conclude sig ctx (DQCtorCong k dSig ds) = do
     QKPoint => pure ()
     _ => kerr "derivation: el-qiit-intro-cong: not a point constructor"
   (tel, _, _) <- liftQE (reflTel sg (qwAt k) entry)
-  triples <- traverse (\d => conclude sig ctx d >>= needElEq) ds
+  triples <- traverse (\d => conclude env sig ctx d >>= needElEq) ds
   let es0 = map (\(a, _, _) => a) triples
   let es1 = map (\(_, b, _) => b) triples
   if length es0 == length tel then pure ()
@@ -2062,8 +2092,8 @@ conclude sig ctx (DQCtorCong k dSig ds) = do
       Just want => alphaTy "el-qiit-intro-cong" ety want
       Nothing => kerr "derivation: el-qiit-intro-cong: telescope instantiation failed"
     goChk tel (S i) rest es0
-conclude sig ctx (DQMot dSig ds) = do
-  sg <- conclude sig ctx dSig >>= needQSig
+conclude env sig ctx (DQMot dSig ds) = do
+  sg <- conclude env sig ctx dSig >>= needQSig
   mots <- goMots sg (qPositions QKSort sg) ds
   pure (JMot sg mots)
  where
@@ -2071,12 +2101,12 @@ conclude sig ctx (DQMot dSig ds) = do
   goMots sg [] [] = pure []
   goMots sg (sj :: sjs) (d :: rest) = do
     (mctx, _, _) <- qSortCtx sig ctx sg sj
-    mot <- conclude sig mctx d >>= needTy
+    mot <- conclude env sig mctx d >>= needTy
     more <- goMots sg sjs rest
     pure (mot :: more)
   goMots _ _ _ = kerr "derivation: mot: motive count mismatch"
-conclude sig ctx (DQDalg dMot ds) = do
-  (sg, mots) <- conclude sig ctx dMot >>= needMot
+conclude env sig ctx (DQDalg dMot ds) = do
+  (sg, mots) <- conclude env sig ctx dMot >>= needMot
   mths <- goMths sg mots (qPositions QKPoint sg) ds
   pure (JDalg sg mots mths)
  where
@@ -2084,13 +2114,13 @@ conclude sig ctx (DQDalg dMot ds) = do
   goMths sg mots [] [] = pure []
   goMths sg mots (cj :: cjs) (d :: rest) = do
     mty <- liftQE (methodTy sg mots cj)
-    (m, mty') <- conclude sig ctx d >>= needEl
+    (m, mty') <- conclude env sig ctx d >>= needEl
     alphaTy "dalg (method)" mty' mty
     more <- goMths sg mots cjs rest
     pure (m :: more)
   goMths _ _ _ _ = kerr "derivation: dalg: method count mismatch"
-conclude sig ctx (DQEProb dDalg ds) = do
-  (sg, mots, mths) <- conclude sig ctx dDalg >>= needDalg
+conclude env sig ctx (DQEProb dDalg ds) = do
+  (sg, mots, mths) <- conclude env sig ctx dDalg >>= needDalg
   goCohs sg mots mths (qPositions QKEq sg) ds
   pure (JEProb sg mots mths)
  where
@@ -2099,14 +2129,14 @@ conclude sig ctx (DQEProb dDalg ds) = do
   goCohs sg mots mths (ej :: ejs) (d :: rest) = do
     (dtel, _, lhs, rhs, cty) <- liftQE (coherenceAt sg mots mths ej)
     let cctx = foldl (:<) ctx dtel
-    (l, r, ety) <- conclude sig cctx d >>= needElEq
+    (l, r, ety) <- conclude env sig cctx d >>= needElEq
     alphaEl "eprob (coherence l)" l lhs
     alphaEl "eprob (coherence r)" r rhs
     alphaTy "eprob (coherence ty)" ety cty
     goCohs sg mots mths ejs rest
   goCohs _ _ _ _ _ = kerr "derivation: eprob: coherence count mismatch"
-conclude sig ctx (DQSect dMot ds) = do
-  (sg, mots) <- conclude sig ctx dMot >>= needMot
+conclude env sig ctx (DQSect dMot ds) = do
+  (sg, mots) <- conclude env sig ctx dMot >>= needMot
   hs <- goSects sg mots (qPositions QKSort sg) ds
   pure (JSect sg mots hs)
  where
@@ -2117,23 +2147,23 @@ conclude sig ctx (DQSect dMot ds) = do
     mot <- case getAt so mots of
              Just m => pure m
              Nothing => kerr "derivation: sect: motive missing"
-    (h, hty) <- conclude sig mctx d >>= needEl
+    (h, hty) <- conclude env sig mctx d >>= needEl
     alphaTy "sect" hty mot
     more <- goSects sg mots sjs rest
     pure (h :: more)
   goSects _ _ _ _ = kerr "derivation: sect: candidate count mismatch"
-conclude sig ctx (DQElim k dEP dSp dW) = do
-  (sg, mots, mths) <- conclude sig ctx dEP >>= needEProb
-  (es, w, motK) <- qElimEnd sig ctx sg mots k dSp dW
+conclude env sig ctx (DQElim k dEP dSp dW) = do
+  (sg, mots, mths) <- conclude env sig ctx dEP >>= needEProb
+  (es, w, motK) <- qElimEnd env sig ctx sg mots k dSp dW
   pure (JEl (QElim sg k mots mths (cast es) w)
             (substTy motK (Ext (foldl Ext Id es) w)))
-conclude sig ctx (DQEta k dEP dSect dAgs dSp dW) = do
-  (sg, mots, mths) <- conclude sig ctx dEP >>= needEProb
-  (sg', mots', hs) <- conclude sig ctx dSect >>= needSect
+conclude env sig ctx (DQEta k dEP dSect dAgs dSp dW) = do
+  (sg, mots, mths) <- conclude env sig ctx dEP >>= needEProb
+  (sg', mots', hs) <- conclude env sig ctx dSect >>= needSect
   if sg' == sg && mots' == mots then pure ()
     else kerr "derivation: el-qiit-eta: sect premise at a different problem"
   goAgrees sg mots mths hs (qPositions QKPoint sg) dAgs
-  (es, w, motK) <- qElimEnd sig ctx sg mots k dSp dW
+  (es, w, motK) <- qElimEnd env sig ctx sg mots k dSp dW
   so <- case qOrdinal QKSort sg k of
           Just x => pure x
           Nothing => kerr "derivation: el-qiit-eta: sort ordinal"
@@ -2165,14 +2195,14 @@ conclude sig ctx (DQEta k dEP dSect dAgs dSp dW) = do
     let ctor = QCtor sg cj (varSpine (length tel))
     let inst = Ext (foldl Ext Id (toList idx)) ctor
     rhs <- liftQE (qSectRhs sg mots mths hs cj (varSpine (length tel)))
-    (l, r, ety) <- conclude sig cctx d >>= needElEq
+    (l, r, ety) <- conclude env sig cctx d >>= needElEq
     alphaEl "el-qiit-eta (agreement l)" l (substElem hS inst)
     alphaEl "el-qiit-eta (agreement r)" r rhs
     alphaTy "el-qiit-eta (agreement ty)" ety (substTy motS inst)
     goAgrees sg mots mths hs cjs rest
   goAgrees _ _ _ _ _ _ = kerr "derivation: el-qiit-eta: agreement count mismatch"
-conclude sig ctx (DQPath k dSig ds) = do
-  sg <- conclude sig ctx dSig >>= needQSig
+conclude env sig ctx (DQPath k dSig ds) = do
+  sg <- conclude env sig ctx dSig >>= needQSig
   entry <- case qEntry sg k of
              Just e => pure e
              Nothing => kerr "derivation: el-qiit-path: position out of range"
@@ -2180,7 +2210,7 @@ conclude sig ctx (DQPath k dSig ds) = do
     QKEq => pure ()
     _ => kerr "derivation: el-qiit-path: not an equation constructor"
   (tel, _, _) <- liftQE (reflTel sg (qwAt k) entry)
-  es <- qSpine "el-qiit-path" sig ctx ds tel
+  es <- qSpine env "el-qiit-path" sig ctx ds tel
   (wEnd, hd) <- liftQE (walkVals sg (qwAt k) entry es)
   (lq, rq, uq) <- liftQE (eqHead hd)
   l <- liftQE (reflTm sg wEnd lq)
@@ -2190,82 +2220,82 @@ conclude sig ctx (DQPath k dSig ds) = do
 
 -- ===== The ToS family (dual zone Γ ; Φ) =====
 
-concludeQTy sig ctx phi DQTyUniv = pure QU
-concludeQTy sig ctx phi (DQTyEl dT) = do
-  (t, tty) <- concludeQTm sig ctx phi dT
+concludeQTy env sig ctx phi DQTyUniv = pure QU
+concludeQTy env sig ctx phi (DQTyEl dT) = do
+  (t, tty) <- concludeQTm env sig ctx phi dT
   case tty of
     QU => pure (QEl t)
     _ => kerr "derivation: qty-el: code premise not at U"
-concludeQTy sig ctx phi (DQTyPiExt dA dB) = do
-  a <- conclude sig ctx dA >>= needTy
-  b <- concludeQTy sig (ctx :< a) (phiWkNova phi) dB
+concludeQTy env sig ctx phi (DQTyPiExt dA dB) = do
+  a <- conclude env sig ctx dA >>= needTy
+  b <- concludeQTy env sig (ctx :< a) (phiWkNova phi) dB
   pure (QPiExt a b)
-concludeQTy sig ctx phi (DQTyPiInd dT dB) = do
-  (t, tty) <- concludeQTm sig ctx phi dT
+concludeQTy env sig ctx phi (DQTyPiInd dT dB) = do
+  (t, tty) <- concludeQTm env sig ctx phi dT
   case tty of
     QU => do
-      b <- concludeQTy sig ctx (phi :< QEl t) dB
+      b <- concludeQTy env sig ctx (phi :< QEl t) dB
       pure (QPiInd t b)
     _ => kerr "derivation: qty-pi-ind: domain code not at U"
-concludeQTy sig ctx phi (DQTySub dS dA) = do
-  (sg, phi1) <- concludeQSub sig ctx phi dS
-  a <- concludeQTy sig ctx phi1 dA
+concludeQTy env sig ctx phi (DQTySub dS dA) = do
+  (sg, phi1) <- concludeQSub env sig ctx phi dS
+  a <- concludeQTy env sig ctx phi1 dA
   pure (qSubTy sg a)
-concludeQTy sig ctx phi d = kerr "derivation: expected a qty node"
+concludeQTy env sig ctx phi d = kerr "derivation: expected a qty node"
 
-concludeQTm sig ctx phi (DQTmVar i) =
+concludeQTm env sig ctx phi (DQTmVar i) =
   case phiAt phi i of
     Just a => pure (QVar i, a)
     Nothing => kerr "derivation: qtm-var: index out of range"
-concludeQTm sig ctx phi (DQTmAppExt dF dE) = do
-  (f, fty) <- concludeQTm sig ctx phi dF
+concludeQTm env sig ctx phi (DQTmAppExt dF dE) = do
+  (f, fty) <- concludeQTm env sig ctx phi dF
   case fty of
     QPiExt a b => do
-      (e, ety) <- conclude sig ctx dE >>= needEl
+      (e, ety) <- conclude env sig ctx dE >>= needEl
       alphaTy "qtm-app-ext" ety a
       pure (QAppE f e, substQTy b (Ext Id e))
     _ => kerr "derivation: qtm-app-ext: not at an external ⇛"
-concludeQTm sig ctx phi (DQTmAppInd dF dA) = do
-  (f, fty) <- concludeQTm sig ctx phi dF
+concludeQTm env sig ctx phi (DQTmAppInd dF dA) = do
+  (f, fty) <- concludeQTm env sig ctx phi dF
   case fty of
     QPiInd u b => do
-      (a, aty) <- concludeQTm sig ctx phi dA
+      (a, aty) <- concludeQTm env sig ctx phi dA
       if aty == QEl u then pure ()
         else kerr "derivation: qtm-app-ind: argument not at the domain sort"
       pure (QAppI f a, qSubTy (QSExt QSId a) b)
     _ => kerr "derivation: qtm-app-ind: not at an inductive ⇛"
-concludeQTm sig ctx phi (DQTmEq dL dR) = do
-  (l, lty) <- concludeQTm sig ctx phi dL
-  (r, rty) <- concludeQTm sig ctx phi dR
+concludeQTm env sig ctx phi (DQTmEq dL dR) = do
+  (l, lty) <- concludeQTm env sig ctx phi dL
+  (r, rty) <- concludeQTm env sig ctx phi dR
   case (lty, rty) of
     (QEl u, QEl u') =>
       if u == u'
         then pure (QEqC l r u, QU)
         else kerr "derivation: qtm-eq: sides at different sorts"
     _ => kerr "derivation: qtm-eq: sides not at El of a sort"
-concludeQTm sig ctx phi (DQTmSub dS dT) = do
-  (sg, phi1) <- concludeQSub sig ctx phi dS
-  (t, a) <- concludeQTm sig ctx phi1 dT
+concludeQTm env sig ctx phi (DQTmSub dS dT) = do
+  (sg, phi1) <- concludeQSub env sig ctx phi dS
+  (t, a) <- concludeQTm env sig ctx phi1 dT
   pure (qSubTm sg t, qSubTy sg a)
-concludeQTm sig ctx phi d = kerr "derivation: expected a qtm node"
+concludeQTm env sig ctx phi d = kerr "derivation: expected a qtm node"
 
-concludeQSub sig ctx phi DQSubId = pure (QSId, phi)
-concludeQSub sig ctx phi DQSubWk =
+concludeQSub env sig ctx phi DQSubId = pure (QSId, phi)
+concludeQSub env sig ctx phi DQSubWk =
   case phi of
     (rest :< _) => pure (QSWk, rest)
     [<] => kerr "derivation: qsub-wk: the ToS zone is empty"
-concludeQSub sig ctx phi (DQSubComp dS dT) = do
-  (sg, phi1) <- concludeQSub sig ctx phi dS
-  (tau, phi2) <- concludeQSub sig ctx phi1 dT
+concludeQSub env sig ctx phi (DQSubComp dS dT) = do
+  (sg, phi1) <- concludeQSub env sig ctx phi dS
+  (tau, phi2) <- concludeQSub env sig ctx phi1 dT
   pure (QSComp tau sg, phi2)
-concludeQSub sig ctx phi (DQSubExt dS dA dT) = do
-  (sg, phi1) <- concludeQSub sig ctx phi dS
-  a <- concludeQTy sig ctx phi1 dA
-  (t, tty) <- concludeQTm sig ctx phi dT
+concludeQSub env sig ctx phi (DQSubExt dS dA dT) = do
+  (sg, phi1) <- concludeQSub env sig ctx phi dS
+  a <- concludeQTy env sig ctx phi1 dA
+  (t, tty) <- concludeQTm env sig ctx phi dT
   if tty == qSubTy sg a then pure ()
     else kerr "derivation: qsub-ext: entry not at 𝔄[ς]"
   pure (QSExt sg t, phi1 :< a)
-concludeQSub sig ctx phi d = kerr "derivation: expected a qsub node"
+concludeQSub env sig ctx phi d = kerr "derivation: expected a qsub node"
 
 -- ===== Entry point =====
 
@@ -2273,14 +2303,14 @@ concludeQSub sig ctx phi d = kerr "derivation: expected a qsub node"
 ||| Left is the rejection reason (fuel exhaustion included).
 export
 concludeItem : Sig -> Nat -> Deriv -> Either KErr Judg
-concludeItem sig fuel d = map fst (runKM (conclude sig [<] d) fuel)
+concludeItem sig fuel d = map fst (runKM (conclude [] sig [<] d) fuel)
 
 ||| Check a derivation in a given context input (a solution's
 ||| telescope); the context's own formation is the caller's burden
 ||| (acceptSolItem replays it first).
 export
 concludeAt : Sig -> Nat -> Ctx -> Deriv -> Either KErr Judg
-concludeAt sig fuel ctx d = map fst (runKM (conclude sig ctx d) fuel)
+concludeAt sig fuel ctx d = map fst (runKM (conclude [] sig ctx d) fuel)
 
 -- ===== ITEM ACCEPTANCE (docs/NovaDerivations.txt, "Items and
 -- acceptance") — the seat's trusted half: replay the derivations the

--- a/src/idris/Nova/Kernel/Reconstruct.idr
+++ b/src/idris/Nova/Kernel/Reconstruct.idr
@@ -1857,11 +1857,28 @@ reLicensed sig ctx step d =
 ||| applied-eliminator fragment).
 headPi : Sig -> Ctx -> Elem -> Elem -> Ty -> Maybe (Ty, Ty)
 headPi sig ctx f e exp =
-  case reInfer sig ctx f emptySkel of
-    Just (_, Ty.PiTy a b) => Just (a, b)
-    _ => do
-      (_, a) <- reInfer sig ctx e emptySkel
-      pure (a, substTy exp Wk)
+  fromStore <|>
+  (case reInfer sig ctx f emptySkel of
+     Just (_, Ty.PiTy a b) => Just (a, b)
+     _ => do
+       (_, a) <- reInfer sig ctx e emptySkel
+       pure (a, substTy exp Wk))
+ where
+  -- the by-term store answers the SHAPE query directly: any known
+  -- typing of f whose type whnf-exposes a Π — no re-inference of
+  -- the spine, no derivation needed (the caller only wants (a, b))
+  fromStore : Maybe (Ty, Ty)
+  fromStore = unsafePerformIO $ do
+    m <- readIORef storedElByTm
+    let (t1, t2) = tmKey ctx f
+    goSt (fromMaybe [] (lookup t2 (fromMaybe [] (lookup t1 m))))
+   where
+    goSt : List (Ty, Deriv) -> IO (Maybe (Ty, Ty))
+    goSt [] = pure Nothing
+    goSt ((ty', _) :: rest) =
+      case nfT sig ty' of
+        Just (Ty.PiTy a b) => pure (Just (a, b))
+        _ => goSt rest
 
 -- one-level children of an element (the common formers), for the
 -- candidate pools of the instantiation searches
@@ -2001,6 +2018,408 @@ reBridgeTSearch : Sig -> Ctx -> Step -> Nat -> Ty -> Ty -> Maybe Deriv
 -- licensed sides against the differing subpair: no
 -- re-instantiation, no enumeration. The congruence walk crosses
 -- only code spellings, whose motives are constant.
+-- ===== the derivation walk: constructive subject reduction =====
+--
+-- The chain replay's exposure links contract spellings; with a
+-- STRUCTURAL witness of the pre-contraction spelling in hand, the
+-- contractum's witness is ASSEMBLED from the redex's premises — the
+-- subject-reduction proof made executable, one ≜ rule at a time —
+-- and the placement machinery reads premises off the witness instead
+-- of reconstructing them (docs/NovaPipeline.txt, "Phase 3 end-state,
+-- revised": premise access is projection, arriving early inside the
+-- replay).
+
+-- Γ ⊦ σ : Δ and Δ ⊦ t : A give Γ ⊦ t[σ] : A[σ]: presupposition over
+-- sub-cong-fix at refl — conclude computes the substituted spellings
+subWrapD : Deriv -> Deriv -> Deriv
+subWrapD dS dT = DPresupElL (DElSubCongFix dS (DElRefl dT))
+
+subWrapDT : Deriv -> Deriv -> Deriv
+subWrapDT dS dT = DPresupTyL (DTySubCongFix dS (DTyRefl dT))
+
+-- under σ = Ext (Chain σ Wk) ☐₀, as a derivation; dA forms the
+-- bound domain at σ's target
+underD : Deriv -> Deriv -> Deriv
+underD dS dA = DSubExt (DSubComp DSubWk dS) dA (DElVar 0)
+
+-- a SubNorm derivation re-read as the Sub derivation of embed es:
+-- terminal for empty, ext for ext — the premise shapes coincide
+subOfSubN : Deriv -> Maybe Deriv
+subOfSubN DSubNEmpty = Just DSubEmpty
+subOfSubN (DSubNExt dEs dA dE) = do
+  dS <- subOfSubN dEs
+  pure (DSubExt dS dA dE)
+subOfSubN _ = Nothing
+
+-- accepted items' body derivations, by Σ name: what a SigVar unfold
+-- substitutes into
+%noinline
+storedSigD : IORef (SortedMap String Deriv)
+storedSigD = mkRef 20 empty
+
+lookupSigDeriv : String -> Maybe Deriv
+lookupSigDeriv x = unsafePerformIO (lookup x <$> readIORef storedSigD)
+
+||| Identity on its last argument; records the derivation as a side
+||| effect carried by the data flow (the callers are pure).
+export
+%noinline
+recordSigDeriv : String -> Deriv -> a -> a
+recordSigDeriv x d v = unsafePerformIO $ do
+  modifyIORef storedSigD (insert x d)
+  pure v
+
+dbgWhen : Bool -> String -> Maybe a -> Maybe a
+dbgWhen True msg m = dbg msg m
+dbgWhen False _ m = m
+
+-- (probe) the head constructor of a derivation, for the walk traces
+dTag : Deriv -> String
+dTag (DElPiE _ _ _) = "app"
+dTag (DElPiI _ _) = "lam"
+dTag (DElSig _ _) = "sigvar"
+dTag (DElVar _) = "var"
+dTag (DRef _) = "ref"
+dTag (DShare _ _ _) = "share"
+dTag (DElTyCoe _ _) = "coe"
+dTag (DPresupElL _) = "presupL"
+dTag (DPresupElR _) = "presupR"
+dTag (DElNatE _ _ _ _) = "natE"
+dTag (DElNatS _) = "natS"
+dTag DElNatZ = "natZ"
+dTag (DNfEq _ _) = "nfeq"
+dTag (DElRefl _) = "refl"
+dTag (DElTrans _ _) = "trans"
+dTag (DElSym _) = "sym"
+dTag (DElSubCongFix _ _) = "subfix"
+dTag (DElSigmaI _ _ _) = "pair"
+dTag (DElSigmaE1 _) = "proj1"
+dTag (DElSigmaE2 _) = "proj2"
+dTag (DElAppCong _ _ _) = "appcong"
+dTag (DElSucCong _) = "succong"
+dTag (DElPairCong _ _ _) = "paircong"
+dTag (DElNatECong _ _ _ _) = "natecong"
+dTag (DElProj1Cong _) = "proj1cong"
+dTag (DElProj2Cong _) = "proj2cong"
+dTag (DElEqTyCoe _ _) = "eqtycoe"
+dTag (DNfExpand _) = "nfexpand"
+dTag (DElSubCong _ _) = "subcong"
+dTag (DBetaAt _ _) = "betaat"
+dTag (DElEqI _) = "eqi"
+dTag (DInvPrfEqL _) = "invprfL"
+dTag (DInvPrfEqR _) = "invprfR"
+dTag (DElLamCong _ _) = "lamcong"
+dTag (DElSigEq _ _) = "sigeq"
+dTag (DElLetCong _ _) = "letcong"
+dTag (DElSumECong _ _ _ _) = "sumecong"
+dTag (DElPiEta _ _ _) = "pieta"
+dTag (DElSigmaEta _ _ _ _) = "sigmaeta"
+dTag (DElNatEta _ _ _ _ _ _ _ _ _) = "nateta"
+dTag (DElLet _ _) = "let"
+dTag (DElReflect _) = "reflect"
+dTag (DCodeEqCong _ _ _) = "codeeqcong"
+dTag _ = "?"
+
+-- a ℕ-constructor spelling's typing, written down directly (a
+-- reflected equation's side has no structural projection, but its
+-- SPELLING is in the walker's hand)
+natWit : Elem -> Maybe Deriv
+natWit NatIntro0 = Just DElNatZ
+natWit (NatIntro1 u) = DElNatS <$> natWit u
+natWit (CtxVar i) = Just (DElVar i)
+natWit (NatElim z st t) =
+  -- an arithmetic spelling: every premise types at the CONSTANT ℕ
+  -- motive, so the eliminator's typing writes itself down
+  [| DElNatE (pure DTyNat) (natWit z) (natWit st) (natWit t) |]
+natWit _ = Nothing
+
+-- a definition's body derivation built ON DEMAND for the walk (the
+-- mirror records solutions it emits, but residue-accepted ones have
+-- no recorded derivation): one plain share-free re-check under its
+-- own allowance, recorded on success
+lazySigDeriv : Sig -> String -> Maybe Deriv
+lazySigDeriv sig x = unsafePerformIO $ do
+  let Just (SigDef delta _ body dty) = sigLookup x sig
+    | _ => pure Nothing
+  let True = not (candPosOver 300 body)
+    | False => pure Nothing
+  was <- readIORef sharingOn
+  spent <- readIORef workBudget
+  writeIORef sharingOn False
+  writeIORef workBudget (max spent 50000)
+  let r = reCheck sig delta body dty emptySkel
+  writeIORef sharingOn was
+  writeIORef workBudget spent
+  case r of
+    Just dw => do
+      modifyIORef storedSigD (insert x dw)
+      pure (Just dw)
+    Nothing => pure Nothing
+
+-- the i-th child spelling, mirroring the walk's descent
+childE : Nat -> Elem -> Maybe Elem
+childE 0 (PiApp f _) = Just f
+childE 1 (PiApp _ a) = Just a
+childE 0 (NatElim z _ _) = Just z
+childE 1 (NatElim _ st _) = Just st
+childE 2 (NatElim _ _ t) = Just t
+childE 0 (NatIntro1 u) = Just u
+childE 0 (SigmaIntro u _) = Just u
+childE 1 (SigmaIntro _ v) = Just v
+childE 0 (SigmaElim1 t) = Just t
+childE 0 (SigmaElim2 t) = Just t
+childE _ _ = Nothing
+
+mutual
+  -- normalize a witness to a structural head: type coercions are
+  -- transparent (the term beneath is what the walk follows), and a
+  -- substitution wrap is PUSHED one level — the executable
+  -- substitution lemma, run lazily
+  dvView : Sig -> Deriv -> Maybe Deriv
+  dvView sig (DElTyCoe _ d) = dvView sig d
+  dvView sig (DPresupElL (DElSubCongFix dS (DElRefl dT))) = do
+    inner <- dvView sig dT
+    pushed <- pushSub sig dS inner
+    dvView sig pushed
+  -- ===== presupposition projection (the design's central dividend):
+  -- a side's typing extracted from an EQUATION derivation is
+  -- structural because the equation's congruence skeleton carries
+  -- its premises — walk it, never re-derive
+  -- general sub-cong (the refl form is the subWrapD composite,
+  -- matched above): a side's typing is the side's typing substituted
+  dvView sig (DPresupElL (DElSubCongFix dS dEq)) =
+    dvView sig (subWrapD dS (DPresupElL dEq))
+  dvView sig (DPresupElR (DElSubCongFix dS dEq)) =
+    dvView sig (subWrapD dS (DPresupElR dEq))
+  dvView sig (DPresupElL (DElRefl d)) = dvView sig d
+  dvView sig (DPresupElR (DElRefl d)) = dvView sig d
+  dvView sig (DPresupElL (DElSym dEq)) = dvView sig (DPresupElR dEq)
+  dvView sig (DPresupElR (DElSym dEq)) = dvView sig (DPresupElL dEq)
+  dvView sig (DPresupElL (DElTrans a _)) = dvView sig (DPresupElL a)
+  dvView sig (DPresupElR (DElTrans _ b)) = dvView sig (DPresupElR b)
+  dvView sig (DPresupElL (DElEqTyCoe _ dEq)) = dvView sig (DPresupElL dEq)
+  dvView sig (DPresupElR (DElEqTyCoe _ dEq)) = dvView sig (DPresupElR dEq)
+  dvView sig (DPresupElL (DNfEq da _)) = dvView sig da
+  dvView sig (DPresupElR (DNfEq _ db)) = dvView sig db
+  dvView sig (DPresupElL (DBetaAt _ d)) = dvView sig d
+  dvView sig (DPresupElR (DBetaAt q d)) = stepTypedE sig q Nothing d >>= dvView sig
+  dvView sig (DPresupElL (DElAppCong dc de dB)) =
+    dvView sig (DElPiE (DPresupElL dc) (DPresupElL de) dB)
+  dvView sig (DPresupElR (DElAppCong dc de dB)) =
+    dvView sig (DElPiE (DPresupElR dc) (DPresupElR de) dB)
+  dvView sig (DPresupElL (DElSucCong dc)) = Just (DElNatS (DPresupElL dc))
+  dvView sig (DPresupElR (DElSucCong dc)) = Just (DElNatS (DPresupElR dc))
+  dvView sig (DPresupElL (DElPairCong dc dB dv)) =
+    Just (DElSigmaI (DPresupElL dc) dB (DPresupElL dv))
+  dvView sig (DPresupElR (DElPairCong dc dB dv)) =
+    Just (DElSigmaI (DPresupElR dc) dB (DPresupElR dv))
+  dvView sig (DPresupElL (DElNatECong dm dz ds dt)) =
+    Just (DElNatE dm (DPresupElL dz) (DPresupElL ds) (DPresupElL dt))
+  dvView sig (DPresupElR (DElNatECong dm dz ds dt)) =
+    Just (DElNatE dm (DPresupElR dz) (DPresupElR ds) (DPresupElR dt))
+  dvView sig (DPresupElL (DElProj1Cong dc)) = Just (DElSigmaE1 (DPresupElL dc))
+  dvView sig (DPresupElR (DElProj1Cong dc)) = Just (DElSigmaE1 (DPresupElR dc))
+  dvView sig (DPresupElL (DElProj2Cong dc)) = Just (DElSigmaE2 (DPresupElL dc))
+  dvView sig (DPresupElR (DElProj2Cong dc)) = Just (DElSigmaE2 (DPresupElR dc))
+  dvView sig d = Just d
+
+  -- σ's n-th entry, as a derivation
+  subEntry : Sig -> Deriv -> Nat -> Maybe Deriv
+  subEntry sig (DSubExt dS' _ dT) Z = Just dT
+  subEntry sig (DSubExt dS' _ _) (S n) = subEntry sig dS' n
+  subEntry sig DSubId n = Just (DElVar n)
+  subEntry sig DSubWk n = Just (DElVar (S n))
+  subEntry sig (DSubComp dA dB) n = subWrapD dA <$> subEntry sig dB n
+  subEntry sig d _ = dbg "wit: sub entry no case \{dTag d}" Nothing
+
+  pushSubN : Sig -> Deriv -> Deriv -> Maybe Deriv
+  pushSubN sig dS DSubNEmpty = Just DSubNEmpty
+  pushSubN sig dS (DSubNExt dEs dA dE) = do
+    dEs' <- pushSubN sig dS dEs
+    pure (DSubNExt dEs' dA (subWrapD dS dE))
+  pushSubN sig dS _ = Nothing
+
+  -- (t[σ])'s node from t's node with σ redistributed to the premises
+  pushSub : Sig -> Deriv -> Deriv -> Maybe Deriv
+  pushSub sig dS dT =
+    case dT of
+      DElVar n => subEntry sig dS n
+      DElSig x dSubN => DElSig x <$> pushSubN sig dS dSubN
+      DElPiE dF dE dB =>
+        Just (DElPiE (subWrapD dS dF) (subWrapD dS dE)
+                     (subWrapDT (underD dS (DPresupElTy dE)) dB))
+      DElPiI dA dBody =>
+        Just (DElPiI (subWrapDT dS dA) (subWrapD (underD dS dA) dBody))
+      DElNatE dM dZ dSt dT' =>
+        Just (DElNatE (subWrapDT (underD dS DTyNat) dM)
+                      (subWrapD dS dZ)
+                      (subWrapD (underD (underD dS DTyNat) dM) dSt)
+                      (subWrapD dS dT'))
+      DElNatZ => Just DElNatZ
+      DElNatS d => Just (DElNatS (subWrapD dS d))
+      DElSigmaI dU dB dV =>
+        Just (DElSigmaI (subWrapD dS dU)
+                        (subWrapDT (underD dS (DPresupElTy dU)) dB)
+                        (subWrapD dS dV))
+      DElSigmaE1 d => Just (DElSigmaE1 (subWrapD dS d))
+      DElSigmaE2 d => Just (DElSigmaE2 (subWrapD dS d))
+      DElEqI d => Just (DElEqI (DElSubCongFix dS d))
+      _ => dbg "wit: push no case \{dTag dT}.\{case dT of
+                                                  DPresupElR e => dTag e
+                                                  DPresupElL e => dTag e
+                                                  _ => "-"}" Nothing
+
+  -- the redex's contraction, witnessed: exactly step1E's head cases,
+  -- each contractum's derivation assembled from the redex's premises
+  headTyped : Sig -> Maybe Elem -> Deriv -> Maybe Deriv
+  headTyped sig me d = do
+    v <- dbg "wit: no head view" (dvView sig d)
+    case v of
+      DElPiE dF dE dB => do
+        vF <- dbg "wit: head fn no view" (dvView sig dF)
+        let DElPiI dA dBody = vF
+          | _ => dbg "wit: head fn not lam: \{dTag vF}" Nothing
+        -- the argument's typing may spell the domain differently
+        -- than the λ's own formation (recorded vs re-inferred
+        -- spellings): sub-ext checks them EXACTLY — coerce
+        let dE' = DElTyCoe (DNfEqTy (DPresupElTy dE) dA) dE
+        pure (subWrapD (DSubExt DSubId dA dE') dBody)
+      DElSig x dSubN => do
+        dBody <- dbg "wit: no sig deriv \{x}"
+                   (lookupSigDeriv x <|> lazySigDeriv sig x)
+        dS <- dbg "wit: head subN" (subOfSubN dSubN)
+        pure (subWrapD dS dBody)
+      DElNatE dM dZ dSt dT => do
+        vT <- dbg "wit: head scrutinee no view"
+                (dvView sig dT
+                 <|> (me >>= childE 2 >>= natWit))
+        case vT of
+          DElNatZ => Just dZ
+          DElNatS dN =>
+            Just (subWrapD (DSubExt (DSubExt DSubId DTyNat dN) dM
+                                    (DElNatE dM dZ dSt dN)) dSt)
+          _ => dbg "wit: head scrutinee: \{dTag vT}" Nothing
+      DElSigmaE1 dP => do
+        vP <- dvView sig dP
+        let DElSigmaI dU _ _ = vP
+          | _ => dbg "wit: head proj1: \{dTag vP}" Nothing
+        Just dU
+      DElSigmaE2 dP => do
+        vP <- dvView sig dP
+        let DElSigmaI dU dB dV = vP
+          | _ => dbg "wit: head proj2: \{dTag vP}" Nothing
+        Just (DElTyCoe (DNfEqTy (DPresupElTy dV)
+                (subWrapDT (DSubExt DSubId (DPresupElTy dU) (DElSigmaE1 dP)) dB)) dV)
+      _ => dbg "wit: head no case" Nothing
+
+  ||| One ≜ contraction at a path, on the WITNESS: the enclosing nodes
+  ||| rebuild around the stepped premise.
+  stepTypedE : Sig -> List Nat -> Maybe Elem -> Deriv -> Maybe Deriv
+  stepTypedE sig [] me d = headTyped sig me d
+  stepTypedE sig (i :: p) me d = do
+    v <- dbg "wit: no view at \{show (i :: p)}" (dvView sig d)
+    let mc = me >>= childE i
+    case (v, i) of
+      (DElPiE dF dE dB, 0) => (\x => DElPiE (reTyped dF x) dE dB) <$> stepTypedE sig p mc dF
+      (DElPiE dF dE dB, 1) => (\x => DElPiE dF (reTyped dE x) dB) <$> stepTypedE sig p mc dE
+      (DElNatE dM dZ dSt dT, 0) => (\x => DElNatE dM (reTyped dZ x) dSt dT) <$> stepTypedE sig p mc dZ
+      (DElNatE dM dZ dSt dT, 1) => (\x => DElNatE dM dZ (reTyped dSt x) dT) <$> stepTypedE sig p mc dSt
+      (DElNatE dM dZ dSt dT, 2) => (\x => DElNatE dM dZ dSt (reTyped dT x)) <$> stepTypedE sig p mc dT
+      (DElNatS d', 0) => (DElNatS . reTyped d') <$> stepTypedE sig p mc d'
+      (DElSigmaI dU dB dV, 0) => (\x => DElSigmaI (reTyped dU x) dB dV) <$> stepTypedE sig p mc dU
+      (DElSigmaI dU dB dV, 1) => (\x => DElSigmaI dU dB (reTyped dV x)) <$> stepTypedE sig p mc dV
+      (DElSigmaE1 d', 0) => (DElSigmaE1 . reTyped d') <$> stepTypedE sig p mc d'
+      (DElSigmaE2 d', 0) => (DElSigmaE2 . reTyped d') <$> stepTypedE sig p mc d'
+      _ => dbg "wit: no case at \{show (i :: p)}: \{dTag v}" Nothing
+   where
+    -- a stepped premise concludes at an nf-EQUAL but possibly
+    -- differently-spelled type (an unfold rewrites the type's spelling
+    -- too); the enclosing node demands the ORIGINAL spelling exactly —
+    -- coerce back along nf-eq of the two presupposed formations
+    reTyped : Deriv -> Deriv -> Deriv
+    reTyped old new = DElTyCoe (DNfEqTy (DPresupElTy new) (DPresupElTy old)) new
+
+-- the chain's rolling STRUCTURAL witness (alongside the compact
+-- presupposition witness): set per side, transformed per exposure,
+-- dropped where a transformation is beyond the current rule set
+%noinline
+chainWit : IORef (Maybe Deriv)
+chainWit = mkRef 21 Nothing
+
+%noinline
+setChainWit : Maybe Deriv -> Maybe ()
+setChainWit w = unsafePerformIO $ do
+  writeIORef chainWit w
+  pure (Just ())
+
+%noinline
+readChainWit : () -> Maybe Deriv
+readChainWit _ = unsafePerformIO (readIORef chainWit)
+
+-- an equation replay is RE-ENTRANT (a chain step licenses through
+-- nested replays, each seeding its own witness and clearing it on
+-- exit): the outer chain's witness is restored around every body
+%noinline
+restoreWitAfter : Maybe Deriv -> Maybe a -> Maybe a
+restoreWitAfter saved r = unsafePerformIO $ do
+  writeIORef chainWit saved
+  pure r
+
+
+-- the raw by-term store entry: a plain structural derivation (births
+-- are stored unshared; DRef citations are added only when SERVED),
+-- so the walk and conclude can both read it
+elWitFor : Sig -> Ctx -> Elem -> Maybe Deriv
+elWitFor sig ctx e = unsafePerformIO $ do
+  m <- readIORef storedElByTm
+  let (t1, t2) = tmKey ctx e
+  case fromMaybe [] (lookup t2 (fromMaybe [] (lookup t1 m))) of
+    ((_, dw) :: _) => pure (Just dw)
+    [] => pure Nothing
+
+witEl : Sig -> Ctx -> Deriv -> Maybe (Elem, Ty)
+witEl sig ctx dw =
+  case runKM (conclude [] sig ctx dw) fuelR of
+    Right (JEl e t, _) => Just (e, t)
+    _ => Nothing
+
+witTy : Sig -> Ctx -> Deriv -> Maybe Ty
+witTy sig ctx dw =
+  case runKM (conclude [] sig ctx dw) fuelR of
+    Right (JTy t, _) => Just t
+    _ => Nothing
+
+-- a structural witness built fresh: reInfer with sharing OFF, so no
+-- citation lands inside (a DRef concludes only under its DShare
+-- binding, and the witness must conclude standalone at every level
+-- of the walk)
+plainWit : Sig -> Ctx -> Elem -> Maybe Deriv
+plainWit sig ctx e = unsafePerformIO $ do
+  was <- readIORef sharingOn
+  spent <- readIORef workBudget
+  writeIORef sharingOn False
+  -- one witness per chain side: worth its own small allowance even
+  -- when the item's budget has drained (it REPLACES the per-level
+  -- re-inference that used to drain it)
+  writeIORef workBudget (max spent 50000)
+  let r = fst <$> reInfer sig ctx e emptySkel
+  case r of
+    Just dw => do writeIORef sharingOn was; writeIORef workBudget spent; pure (Just dw)
+    Nothing => do writeIORef sharingOn was; writeIORef workBudget spent; pure Nothing
+
+-- the witness cracked to a structural node, guarded by its erasure:
+-- a witness that no longer speaks `cur` is silently dropped and the
+-- caller falls back to reconstruction
+witView : Sig -> Ctx -> Elem -> Maybe Deriv -> Maybe Deriv
+witView sig ctx cur wit = do
+  w <- wit
+  case runKM (conclude [] sig ctx w) fuelR of
+    Right (JEl e _, _) =>
+      if e == cur then dbg "wit: view crack miss \{dTag w}" (dvView sig w)
+        else dbg "wit: view speaks \{show e} not \{show cur}" Nothing
+    Right _ => dbg "wit: view not an El judgment" Nothing
+    Left err => dbg "wit: view conclude: \{err}" Nothing
+
 stKey : Maybe Step -> String
 stKey Nothing = "-"
 stKey (Just st) =
@@ -2009,6 +2428,71 @@ stKey (Just st) =
      LProof pf => show pf
      LBeta => "|β"
      LPath _ k th => "|π\{show k}\{show (toList th)}")
+
+-- ===== first-order matching of ∀-statement sides =====
+-- pattern vars are the statement's telescope+Π binders (0..n-1,
+-- innermost first); k tracks binders crossed inside the pattern — a
+-- binding is taken only at depth 0 (no escape analysis needed),
+-- deeper occurrences must repeat it
+matchStE : Nat -> Nat -> Elem -> Elem -> SortedMap Nat Elem -> Maybe (SortedMap Nat Elem)
+matchStE n k (CtxVar p) tgt acc =
+  if p < k
+    then case tgt of
+           CtxVar q => if q == p then Just acc else Nothing
+           _ => Nothing
+    else if p < k + n
+      then (if k == 0
+              then case lookup p acc of
+                     Just t0 => if t0 == tgt then Just acc else Nothing
+                     Nothing => Just (insert p tgt acc)
+              else Nothing)
+      else case tgt of
+             CtxVar q => if q + n == p then Just acc else Nothing
+             _ => Nothing
+matchStE n k NatIntro0 NatIntro0 acc = Just acc
+matchStE n k Star Star acc = Just acc
+matchStE n k (NatIntro1 u) (NatIntro1 v) acc = matchStE n k u v acc
+matchStE n k (NatElim z0 s0 t0) (NatElim z1 s1 t1) acc =
+  matchStE n k z0 z1 acc >>= matchStE n (2 + k) s0 s1 >>= matchStE n k t0 t1
+matchStE n k (PiApp f u) (PiApp g v) acc =
+  matchStE n k f g acc >>= matchStE n k u v
+matchStE n k (PiIntro f) (PiIntro g) acc = matchStE n (S k) f g acc
+matchStE n k (SigmaIntro u0 v0) (SigmaIntro u1 v1) acc =
+  matchStE n k u0 u1 acc >>= matchStE n k v0 v1
+matchStE n k (SigmaElim1 u) (SigmaElim1 v) acc = matchStE n k u v acc
+matchStE n k (SigmaElim2 u) (SigmaElim2 v) acc = matchStE n k u v acc
+matchStE n k (Inj1 u) (Inj1 v) acc = matchStE n k u v acc
+matchStE n k (Inj2 u) (Inj2 v) acc = matchStE n k u v acc
+matchStE n k (Elem.SigVar nm0 es0) (Elem.SigVar nm1 es1) acc =
+  if nm0 == nm1
+    then goEs (toList es0) (toList es1) acc
+    else Nothing
+ where
+  goEs : List Elem -> List Elem -> SortedMap Nat Elem -> Maybe (SortedMap Nat Elem)
+  goEs [] [] a = Just a
+  goEs (u :: us) (v :: vs) a = matchStE n k u v a >>= goEs us vs
+  goEs _ _ _ = Nothing
+matchStE _ _ _ _ _ = Nothing
+
+-- statement var i (de Bruijn, innermost 0) sits at argument slot
+-- n-1-i (outermost argument first)
+matchStTuple : Nat -> Elem -> Elem -> Maybe (List Elem)
+matchStTuple Z _ _ = Nothing
+matchStTuple n pat tgt = do
+  m <- matchStE n 0 pat tgt empty
+  traverse (\j => lookup (minus n (S j)) m) [0 .. minus n 1]
+
+||| A step's ∀-lemma instantiated against a pair — by recorded
+||| instance, by enumeration over a pool, and by first-order MATCHING
+||| of the lemma's nf'd statement sides against the pair (pass an
+||| empty pool for matching alone; it is cheap and needs no search).
+lemmaInsts : Sig -> Ctx -> Step -> Nat -> List Elem -> (Elem, Elem) -> List (Deriv, Elem, Elem, Ty, Elem)
+
+||| The signature's own proven equation laws, ∀-instantiated by
+||| matching against the pair. CLOSED statements: no recorded-context
+||| skew can corrupt the instance, where a certificate step's
+||| recording may speak another context's variables.
+sigLawInsts : Sig -> Ctx -> (Elem, Elem) -> List (Elem, Elem, Deriv)
 
 lemBridgeT : Sig -> Ctx -> List Step -> Nat -> Ty -> Ty -> Maybe Deriv
 lemBridgeT _ _ _ Z _ _ = Nothing
@@ -2021,23 +2505,41 @@ lemBridgeT sig ctx pool (S fuel) (El x) (El y) =
       let is = recInsts
       let False = null is
         | True => Nothing
-      withMemo memoLB "\{show (length (toList ctx))}|LB|\{concatMap (stKey . Just) pool}|\{show x}=\{show y}" $ do
-        dq <- diffPosE sig 64 [] x y
-        goPre is (reverse (inits dq))
+      _ <- if reconDebug
+             then trace "wit: LB \{show (length is)} insts FOR \{show x} VS \{show y}: \{show (map (\(u, v, _) => (u, v)) is)}" (Just ())
+             else Just ()
+      withMemo memoLB "\{show (length (toList ctx))}|LB\{show fuel}|\{concatMap (stKey . Just) pool}|\{show x}=\{show y}" $ do
+        dq <- dbg "LB\{show fuel}: no diff" (diffPosE sig 64 [] x y)
+        dbg "LB\{show fuel}: dead at dq=\{show dq} x=\{show x} y=\{show y}"
+          (goPre is (reverse (inits dq)))
  where
   -- each pool step's licensed equation, at both its normalized and
   -- statement spellings, with its DERIVATION — matching is exact
   -- comparison, placement is direct congruence assembly
+  -- an instance's engine spelling may still hold a β-redex the
+  -- GOAL's fully-normalized spelling has contracted (the nf'd law
+  -- function applied to constructor-headed arguments): offer the
+  -- nf'd sides too, the equation conjugated by nf-expansion
+  atNf : (Deriv, Elem, Elem) -> List (Elem, Elem, Deriv)
+  atNf (dEq, le, re) =
+    case (nfE sig le, nfE sig re) of
+      (Just leN, Just reN) =>
+        if leN == le && reN == re then []
+          else [(leN, reN,
+                 DElTrans (DElSym (DNfExpand (DPresupElL dEq)))
+                   (DElTrans dEq (DNfExpand (DPresupElR dEq))))]
+      _ => []
+
   recInsts : List (Elem, Elem, Deriv)
   recInsts =
     concatMap (\st =>
       case st.lic of
         LProof _ =>
           (case reLicensed sig ctx st 0 of
-             Just (dEq, le, re, _) => [(le, re, dEq)]
+             Just (dEq, le, re, _) => [(le, re, dEq)] ++ atNf (dEq, le, re)
              Nothing => [])
           ++ (case reLicensedRaw sig ctx st 0 of
-                Just (dEq, le, re, _) => [(le, re, dEq)]
+                Just (dEq, le, re, _) => [(le, re, dEq)] ++ atNf (dEq, le, re)
                 Nothing => [])
         _ => []) pool
 
@@ -2093,26 +2595,74 @@ lemBridgeT sig ctx pool (S fuel) (El x) (El y) =
       | _ => Nothing
     let False = xa == ya
       | True => Nothing
-    fullClose xa ya recIs
-      <|> (do -- one-sided steps: only at the DEEPEST disagreement
-              -- (recursion at every prefix branches exponentially)
-              let True = deepest
-                | False => Nothing
-              (dEq, re) <- pickBy xa recIs
-              (dc, x') <- place p x dEq re
-              let False = x' == x
-                | True => Nothing
+    -- recorded instances, plus instances PROPOSED by matching each
+    -- pool lemma's statement against this pair (empty pool: matching
+    -- only, no enumeration) — a shift at freshly combined arguments
+    -- exists in no recording
+    let allIs = recIs
+                ++ concatMap (\st =>
+                     map (\(dEq, le, re, _, _) => (le, re, dEq))
+                       (lemmaInsts sig ctx st 0 [] (xa, ya))) pool
+                ++ (if candPosOver 60 xa || candPosOver 60 ya
+                      then [] else sigLawInsts sig ctx (xa, ya))
+    _ <- if reconDebug
+           then trace "LB\{show fuel}: closeAt \{show p} insts \{show (length allIs)} xa=\{show xa} ya=\{show ya}" (Just ())
+           else Just ()
+    fullClose xa ya allIs
+      <|> goX (picksIn xa allIs)
+      <|> goY (picksIn ya allIs)
+   where
+    firstPosIn : Elem -> Elem -> Maybe (List Nat)
+    firstPosIn sub z = goQ ([] :: snd (candPosB 160 [] z))
+     where
+      goQ : List (List Nat) -> Maybe (List Nat)
+      goQ [] = Nothing
+      goQ (q :: qs) =
+        case subAtE q z of
+          Just (Left sq) => if sq == sub then Just q else goQ qs
+          _ => goQ qs
+
+    -- every (instance, occurrence) candidate within the prefix's
+    -- subterm — the one-sided recursion BACKTRACKS across them (the
+    -- first pick may be a cycle; the productive one may come later)
+    picksIn : Elem -> List (Elem, Elem, Deriv) -> List (Deriv, Elem, List Nat)
+    picksIn za is =
+      concatMap (\(leN, reN, dEq) =>
+        (case firstPosIn leN za of
+           Just q => [(dEq, reN, q)]
+           Nothing => [])
+        ++ (case firstPosIn reN za of
+              Just q => [(DElSym dEq, leN, q)]
+              Nothing => [])) is
+
+    goX : List (Deriv, Elem, List Nat) -> Maybe Deriv
+    goX [] = Nothing
+    goX ((dEq, re, q) :: rest) =
+      (do (dc, x') <- place (p ++ q) x dEq re
+          let False = x' == x
+            | True => Nothing
+          -- the terminal rewrite needs no recursion (and must not
+          -- pay a fuel level for the refl close)
+          if x' == y
+            then pure (DTyElCong dc)
+            else do
               rec <- lemBridgeT sig ctx pool fuel (El x') (El y)
               pure (DTyTrans (DTyElCong dc) rec))
-      <|> (do let True = deepest
-                | False => Nothing
-              (dEq, re) <- pickBy ya recIs
-              (dc, y') <- place p y dEq re
-              let False = y' == y
-                | True => Nothing
+      <|> goX rest
+
+    goY : List (Deriv, Elem, List Nat) -> Maybe Deriv
+    goY [] = Nothing
+    goY ((dEq, re, q) :: rest) =
+      (do (dc, y') <- place (p ++ q) y dEq re
+          let False = y' == y
+            | True => Nothing
+          if y' == x
+            then pure (DTySym (DTyElCong dc))
+            else do
               rec <- lemBridgeT sig ctx pool fuel (El x) (El y')
               pure (DTyTrans rec (DTySym (DTyElCong dc))))
-   where
+      <|> goY rest
+
     fullClose : Elem -> Elem -> List (Elem, Elem, Deriv) -> Maybe Deriv
     fullClose xa ya [] = Nothing
     fullClose xa ya ((leN, reN, dEq) :: more) =
@@ -2137,15 +2687,13 @@ lemBridgeT sig ctx pool (S fuel) (El x) (El y) =
       else if reN == za then Just (DElSym dEq, leN)
       else pickBy za more
 
-  -- the prefix list arrives deepest-first: one-sided recursion is
-  -- allowed only at its head
+  -- the prefix list arrives deepest-first; one-sided recursion is
+  -- allowed at EVERY prefix — the productive rewrite may sit above
+  -- the deepest disagreement (a reassociation at combined arguments)
+  -- and the fuel bound plus the memo keep the walk finite
   goPre : List (Elem, Elem, Deriv) -> List (List Nat) -> Maybe Deriv
   goPre recIs [] = Nothing
-  goPre recIs (p :: ps) = closeAt recIs True p <|> goRest ps
-   where
-    goRest : List (List Nat) -> Maybe Deriv
-    goRest [] = Nothing
-    goRest (q :: qs) = closeAt recIs False q <|> goRest qs
+  goPre recIs (p :: ps) = closeAt recIs True p <|> goPre recIs ps
 -- one side El, the other an EXPOSED former: the unfolding is
 -- blocked behind an index law — rewrite the code by a recorded
 -- instance at an exact occurrence, then close through the oracle
@@ -2237,8 +2785,8 @@ eqAtLem sig ctx dEq cur tgt =
 ||| Placement: rewrite `cur` at `path` by the step's licensed
 ||| equation, emitting the congruence chain; returns the derivation
 ||| (cur ≐ cur′ at the expected type) and cur′.
-rePlaceE : Sig -> Ctx -> Step -> Nat -> List Nat -> Ty -> Elem -> Maybe Deriv -> Maybe (Deriv, Elem, Ty)
-rePlaceE sig ctx step d [] exp cur mty =
+rePlaceE : Sig -> Ctx -> Step -> Nat -> List Nat -> Ty -> Elem -> Maybe Deriv -> Maybe Deriv -> Maybe (Deriv, Elem, Ty)
+rePlaceE sig ctx step d [] exp cur mty wit =
   leafWith True (reLicensedRaw sig ctx step d)
   <|> leafWith False (dbg "leaf: license" (reLicensed sig ctx step d))
  where
@@ -2296,24 +2844,58 @@ rePlaceE sig ctx step d [] exp cur mty =
                 let atN = DElEqTyCoe dBr (DElEqTyCoe (DNfEqTy dT dTN) dEq)
                 pure (DElEqTyCoe (DTySym (DNfExpandTy dE)) atN)
     pure (d', re, if t == exp then t else exp)
-rePlaceE sig ctx step d (i :: p) exp cur mty =
+rePlaceE sig ctx step d (i :: p) exp cur mty wit =
   case (cur, i) of
     (NatIntro1 t, 0) => do
-      (dc0, t', chTy) <- rePlaceE sig ctx step d p Ty.NatTy t Nothing
+      let wt = do DElNatS wN <- witView sig ctx cur wit
+                    | _ => Nothing
+                  Just wN
+      (dc0, t', chTy) <- rePlaceE sig ctx step d p Ty.NatTy t Nothing wt
       dc <- eqAtLem sig ctx dc0 chTy Ty.NatTy
       pure (DElSucCong dc, NatIntro1 t', Ty.NatTy)
-    (PiApp f e, 0) => do
-      (a, b) <- headPi sig ctx f e exp
-      (dc0, f', chTy) <- rePlaceE sig ctx step d p (Ty.PiTy a b) f Nothing
-      dc <- eqAtLem sig ctx dc0 chTy (Ty.PiTy a b)
-      de <- reCheck sig ctx e a emptySkel
-      db <- reTy sig (ctx :< a) b emptySkel
-            <|> Just (DInvPiCod (DPresupElTy (DPresupElL dc)))
-      pure (DElAppCong dc (DElRefl de) db, PiApp f' e, substTy b (Ext Id e))
-    (PiApp f e, 1) => do
+    -- the zipper routes: with the chain's structural witness in hand
+    -- every premise is a PROJECTION — the function's typing, the
+    -- argument's, the codomain's formation are fields of the redex's
+    -- witness, never re-inferred (a contraction-born spine prefix has
+    -- no stored typing to re-infer FROM; the witness is the only
+    -- authority that still speaks it)
+    (PiApp f e, 0) =>
+      (dbgWhen (isJust wit) "wit: app0 zip declined" $ the (Maybe (Deriv, Elem, Ty)) $ do
+        DElPiE wF wE wB <- dbgWhen (isJust wit) "wit: app0 view miss"
+                             (witView sig ctx cur wit)
+          | _ => dbg "wit: app0 head not app" Nothing
+        (_, fty) <- dbg "wit: app0 f conclude miss" (witEl sig ctx wF)
+        let Ty.PiTy a b = fty
+          | _ => dbg "wit: app0 f not at Pi" Nothing
+        (dc0, f', chTy) <- rePlaceE sig ctx step d p (Ty.PiTy a b) f Nothing (Just wF)
+        dc <- eqAtLem sig ctx dc0 chTy (Ty.PiTy a b)
+        pure (DElAppCong dc (DElRefl wE) wB, PiApp f' e, substTy b (Ext Id e)))
+      <|> (do
+        (a, b) <- headPi sig ctx f e exp
+        (dc0, f', chTy) <- rePlaceE sig ctx step d p (Ty.PiTy a b) f Nothing Nothing
+        dc <- eqAtLem sig ctx dc0 chTy (Ty.PiTy a b)
+        de <- reCheck sig ctx e a emptySkel
+        db <- reTy sig (ctx :< a) b emptySkel
+              <|> Just (DInvPiCod (DPresupElTy (DPresupElL dc)))
+        pure (DElAppCong dc (DElRefl de) db, PiApp f' e, substTy b (Ext Id e)))
+    (PiApp f e, 1) =>
+      (dbgWhen (isJust wit) "wit: app1 zip declined" $ the (Maybe (Deriv, Elem, Ty)) $ do
+        DElPiE wF wE wB <- dbgWhen (isJust wit) "wit: app1 view miss"
+                             (witView sig ctx cur wit)
+          | _ => dbg "wit: app1 head not app" Nothing
+        (_, fty) <- dbg "wit: app1 f conclude miss" (witEl sig ctx wF)
+        let Ty.PiTy a b = fty
+          | _ => dbg "wit: app1 f not at Pi" Nothing
+        (dc0, e', chTy) <- rePlaceE sig ctx step d p a e Nothing (Just wE)
+        dc <- eqAtLem sig ctx dc0 chTy a
+        let dS = DSubExtCong (DSubRefl DSubId) (DPresupElTy wE) (DElSym dc)
+        let bridge = DTySubCong dS (DTyRefl wB)
+        pure (DElEqTyCoe bridge (DElAppCong (DElRefl wF) dc wB),
+              PiApp f e', substTy b (Ext Id e)))
+      <|> (do
       (a, b) <- headPi sig ctx f e exp
       df <- reCheck sig ctx f (Ty.PiTy a b) emptySkel
-      (dc0, e', chTy) <- rePlaceE sig ctx step d p a e Nothing
+      (dc0, e', chTy) <- rePlaceE sig ctx step d p a e Nothing Nothing
       dc <- eqAtLem sig ctx dc0 chTy a
       db <- reTy sig (ctx :< a) b emptySkel
             <|> Just (DInvPiCod (DPresupElTy df))
@@ -2331,29 +2913,39 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
           let dS = DSubExtCong (DSubRefl DSubId) dA' (DElSym dc)
           let bridge = DTySubCong dS (DTyRefl db)
           pure (DElEqTyCoe bridge (DElAppCong (DElRefl df) dc db),
-                PiApp f e', substTy b (Ext Id e))
+                PiApp f e', substTy b (Ext Id e)))
     (SigmaIntro u v, 0) => do
       expN <- nfT sig exp
       let Ty.SigmaTy a b = expN
         | _ => Nothing
-      (dc0, u', chTy) <- rePlaceE sig ctx step d p a u Nothing
+      (dc0, u', chTy) <- rePlaceE sig ctx step d p a u Nothing Nothing
       dc <- eqAtLem sig ctx dc0 chTy a
       db <- reTy sig (ctx :< a) b emptySkel
       dv <- reCheck sig ctx v (substTy b (Ext Id u')) emptySkel
       pure (DElPairCong dc db (DElRefl dv), SigmaIntro u' v, expN)
-    (SigmaIntro u v, 1) => do
+    (SigmaIntro u v, 1) =>
+      (dbgWhen (isJust wit) "wit: pair1 zip declined" $ the (Maybe (Deriv, Elem, Ty)) $ do
+        DElSigmaI wU wB wV <- dbgWhen (isJust wit) "wit: pair1 view miss"
+                                (witView sig ctx cur wit)
+          | v => dbg "wit: pair1 not pair: \{dTag v}" Nothing
+        (_, a) <- dbg "wit: pair1 fst conclude miss" (witEl sig ctx wU)
+        b <- dbg "wit: pair1 family conclude miss" (witTy sig (ctx :< a) wB)
+        (dc0, v', chTy) <- rePlaceE sig ctx step d p (substTy b (Ext Id u)) v Nothing (Just wV)
+        dc <- dbg "wit: pair1 eqAtLem miss" (eqAtLem sig ctx dc0 chTy (substTy b (Ext Id u)))
+        pure (DElPairCong (DElRefl wU) wB dc, SigmaIntro u v', Ty.SigmaTy a b))
+      <|> (do
       expN <- nfT sig exp
       let Ty.SigmaTy a b = expN
         | _ => Nothing
       du <- reCheck sig ctx u a emptySkel
       db <- reTy sig (ctx :< a) b emptySkel
-      (dc0, v', chTy) <- rePlaceE sig ctx step d p (substTy b (Ext Id u)) v Nothing
+      (dc0, v', chTy) <- rePlaceE sig ctx step d p (substTy b (Ext Id u)) v Nothing Nothing
       dc <- eqAtLem sig ctx dc0 chTy (substTy b (Ext Id u))
-      pure (DElPairCong (DElRefl du) db dc, SigmaIntro u v', expN)
+      pure (DElPairCong (DElRefl du) db dc, SigmaIntro u v', expN))
     (Inj1 a, 0) =>
       case exp of
         Ty.SumTy l r => do
-          (dc0, a', chTy) <- rePlaceE sig ctx step d p l a Nothing
+          (dc0, a', chTy) <- rePlaceE sig ctx step d p l a Nothing Nothing
           dc <- eqAtLem sig ctx dc0 chTy l
           dr <- reTy sig ctx r emptySkel
           pure (DElInj1Cong dc dr, Inj1 a', Ty.SumTy l r)
@@ -2361,7 +2953,7 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
     (Inj2 b, 0) =>
       case exp of
         Ty.SumTy l r => do
-          (dc0, b', chTy) <- rePlaceE sig ctx step d p r b Nothing
+          (dc0, b', chTy) <- rePlaceE sig ctx step d p r b Nothing Nothing
           dc <- eqAtLem sig ctx dc0 chTy r
           dl <- reTy sig ctx l emptySkel
           pure (DElInj2Cong dc dl, Inj2 b', Ty.SumTy l r)
@@ -2371,8 +2963,22 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
       -- huge spelling that is the blowup — decline fast
       let False = fst (candPosB 501 [] st) == 0 || tySizeFuel 501 [] exp == 0
         | True => Nothing
+      let wsplit = do DElNatE wM wZ wSt wT <- witView sig ctx cur wit
+                        | _ => Nothing
+                      Just (wM, wZ, wSt, wT)
       (dc0, t', chTy) <- rePlaceE sig ctx step d p Ty.NatTy t Nothing
+                           ((\(_, _, _, wT) => wT) <$> wsplit)
       dc <- eqAtLem sig ctx dc0 chTy Ty.NatTy
+      -- the witness route: the MOTIVE is a premise of the witness —
+      -- read, not guessed against re-checked branches
+      let viaWit = the (Maybe (Deriv, Elem, Ty)) $ do
+            (wM, wZ, wSt, _) <- wsplit
+            mot <- witTy sig (ctx :< Ty.NatTy) wM
+            let dS = DSubExtCong (DSubRefl DSubId) DTyNat (DElSym dc)
+            let bridge = DTySubCong dS (DTyRefl wM)
+            pure (DElEqTyCoe bridge
+                    (DElNatECong wM (DElRefl wZ) (DElRefl wSt) dc),
+                  NatElim z st t', substTy mot (Ext Id t))
       let tryMot = \mot => do
             dmot <- dbg "natEmot: motive \{show mot}" (reTy sig (ctx :< Ty.NatTy) mot emptySkel)
             dz <- dbg "natEmot: z" (chkStep sig ctx step d z (substTy mot (Ext Id NatIntro0)))
@@ -2385,7 +2991,8 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
             pure (DElEqTyCoe bridge
                     (DElNatECong dmot (DElRefl dz) (DElRefl dst) dc),
                   NatElim z st t', substTy mot (Ext Id t))
-      tryMot (substTy exp Wk)
+      viaWit
+        <|> tryMot (substTy exp Wk)
         -- the expected type is the motive INSTANCE — at the original
         -- scrutinee if the surroundings kept its spelling, at the
         -- REWRITTEN one if the equation's type already speaks the
@@ -2395,7 +3002,7 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
     (NatElim z st t, 0) => do
       let mot = substTy exp Wk
       dmot <- reTy sig (ctx :< Ty.NatTy) mot emptySkel
-      (dc, z', _) <- rePlaceE sig ctx step d p exp z Nothing
+      (dc, z', _) <- rePlaceE sig ctx step d p exp z Nothing Nothing
       dst <- reCheck sig (ctx :< Ty.NatTy :< mot) st
                (substTy mot (Chain (Ext Wk (NatIntro1 (CtxVar 0))) Wk)) emptySkel
       dt <- reCheck sig ctx t Ty.NatTy emptySkel
@@ -2407,7 +3014,7 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
       dz <- reCheck sig ctx z exp emptySkel
       let sctx = ctx :< Ty.NatTy :< mot
       (dc, st', _) <- rePlaceE sig sctx step (2 + d) p
-                        (substTy mot (Chain (Ext Wk (NatIntro1 (CtxVar 0))) Wk)) st Nothing
+                        (substTy mot (Chain (Ext Wk (NatIntro1 (CtxVar 0))) Wk)) st Nothing Nothing
       dt <- reCheck sig ctx t Ty.NatTy emptySkel
       pure (DElNatECong dmot (DElRefl dz) dc (DElRefl dt),
             NatElim z st' t, exp)
@@ -2419,7 +3026,7 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
           dmot <- reTy sig (ctx :< Ty.SumTy a b) mot emptySkel
           dl <- reCheck sig (ctx :< a) l (substTy exp Wk) emptySkel
           dr <- reCheck sig (ctx :< b) r (substTy exp Wk) emptySkel
-          (dc0, t', chTy) <- rePlaceE sig ctx step d p (Ty.SumTy a b) t Nothing
+          (dc0, t', chTy) <- rePlaceE sig ctx step d p (Ty.SumTy a b) t Nothing Nothing
           dc <- eqAtLem sig ctx dc0 chTy (Ty.SumTy a b)
           pure (DElSumECong dc dmot (DElRefl dl) (DElRefl dr),
                 SumElim l r t', exp)
@@ -2427,7 +3034,7 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
     (Class a, 0) =>
       case exp of
         Ty.Quotient dom rel => do
-          (dc, a', _) <- rePlaceE sig ctx step d p dom a Nothing
+          (dc, a', _) <- rePlaceE sig ctx step d p dom a Nothing Nothing
           dr <- reCheck sig (ctx :< dom :< substTy dom Wk) rel Ty.PropTy emptySkel
           pure (DElClassCong dc dr, Class a', Ty.Quotient dom rel)
         _ => Nothing
@@ -2439,7 +3046,7 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
       let Ty.NuTy f = ttyN
         | _ => Nothing
       let nuT = Ty.NuTy f
-      (dc0, t', chTy) <- rePlaceE sig ctx step d p nuT t Nothing
+      (dc0, t', chTy) <- rePlaceE sig ctx step d p nuT t Nothing Nothing
       dc <- eqAtLem sig ctx dc0 chTy nuT
       dNu <- reTy sig ctx nuT emptySkel
       (dSp, spTy) <- reInfer sig (ctx :< nuT) (Out (CtxVar 0)) emptySkel
@@ -2451,7 +3058,10 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
       ttyN <- nfT sig tty
       let Ty.SigmaTy a _ = ttyN
         | _ => Nothing
-      (dc0, t', chTy) <- rePlaceE sig ctx step d p ttyN t Nothing
+      let wt = do DElSigmaE1 wP <- witView sig ctx cur wit
+                    | _ => Nothing
+                  Just wP
+      (dc0, t', chTy) <- rePlaceE sig ctx step d p ttyN t Nothing wt
       dc <- eqAtLem sig ctx dc0 chTy ttyN
       pure (DElProj1Cong dc, SigmaElim1 t', a)
     (SigmaElim2 t, 0) => do
@@ -2459,7 +3069,10 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
       ttyN <- nfT sig tty
       let Ty.SigmaTy a b = ttyN
         | _ => Nothing
-      (dc0, t', chTy) <- rePlaceE sig ctx step d p ttyN t Nothing
+      let wt = do DElSigmaE2 wP <- witView sig ctx cur wit
+                    | _ => Nothing
+                  Just wP
+      (dc0, t', chTy) <- rePlaceE sig ctx step d p ttyN t Nothing wt
       dc <- eqAtLem sig ctx dc0 chTy ttyN
       -- shift neutralized at source, as at PiApp-1: the first
       -- projections' equation bridges B[id, π₁ t′] back to
@@ -2485,7 +3098,7 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
       dt <- reTy sig ctx t emptySkel
             <|> (DInvCodeEqTy <$> mty)
       (dc, l', _) <- rePlaceE sig ctx step d p t l
-                       (DInvCodeEqL <$> mty)
+                       (DInvCodeEqL <$> mty) Nothing
       dr <- reCheck sig ctx r t emptySkel
             <|> (DInvCodeEqR <$> mty)
       pure (DCodeEqCong (DTyRefl dt) dc (DElRefl dr), Elem.EqTy l' r t, Ty.PropTy)
@@ -2495,7 +3108,7 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
       dl <- reCheck sig ctx l t emptySkel
             <|> (DInvCodeEqL <$> mty)
       (dc, r', _) <- rePlaceE sig ctx step d p t r
-                       (DInvCodeEqR <$> mty)
+                       (DInvCodeEqR <$> mty) Nothing
       pure (DCodeEqCong (DTyRefl dt) (DElRefl dl) dc, Elem.EqTy l r' t, Ty.PropTy)
     (Elem.EqTy l r t, 2) => do
       -- a rewrite in the ∈-slot: the sides ride the CHILD TYPE
@@ -2516,7 +3129,7 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
       let ls = toList es
       e0 <- getAt i ls
       ety <- telInst tel i ls
-      (dc0, e', chTy) <- rePlaceE sig ctx step d p ety e0 Nothing
+      (dc0, e', chTy) <- rePlaceE sig ctx step d p ety e0 Nothing Nothing
       dc <- eqAtLem sig ctx dc0 chTy ety
       dSig <- reQSig sig ctx sg
       ds <- traverse (\(j, ej) =>
@@ -2529,22 +3142,22 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
       (srt, idx) <- either (const Nothing) Just (pointHead sg wEnd hd)
       pure (DQCtorCong k dSig ds, QCtor sg k (cast ls'), QSort sg srt idx)
     (Elem.SumTy a b, 0) => do
-      (dc, a', _) <- rePlaceE sig ctx step d p Ty.UniverseTy a Nothing
+      (dc, a', _) <- rePlaceE sig ctx step d p Ty.UniverseTy a Nothing Nothing
       db <- reCheck sig ctx b Ty.UniverseTy emptySkel
       pure (DCodeSumCong dc (DElRefl db), Elem.SumTy a' b, Ty.UniverseTy)
     (Elem.SumTy a b, 1) => do
       da <- reCheck sig ctx a Ty.UniverseTy emptySkel
-      (dc, b', _) <- rePlaceE sig ctx step d p Ty.UniverseTy b Nothing
+      (dc, b', _) <- rePlaceE sig ctx step d p Ty.UniverseTy b Nothing Nothing
       pure (DCodeSumCong (DElRefl da) dc, Elem.SumTy a b', Ty.UniverseTy)
     _ => Nothing
 
 rePlaceT sig ctx step d (0 :: p) (El e) mtf = do
   (dc, e', _) <- rePlaceE sig ctx step d p Ty.UniverseTy e
-                   (DInvElCode <$> mtf)
+                   (DInvElCode <$> mtf) Nothing
   pure (DTyElCong dc, El e')
 rePlaceT sig ctx step d (0 :: p) (Prf e) mtf = do
   (dc, e', _) <- rePlaceE sig ctx step d p Ty.PropTy e
-                   (DInvPrfCode <$> mtf)
+                   (DInvPrfCode <$> mtf) Nothing
   pure (DTyPrfCong dc, Prf e')
 rePlaceT sig ctx step d (0 :: p) (Ty.PiTy a b) mtf = do
   (dc, a') <- rePlaceT sig ctx step d p a (DInvPiDom <$> mtf)
@@ -2580,7 +3193,7 @@ rePlaceT sig ctx step d (i :: p) (QSort sg k es) mtf = do
   let l = toList es
   e <- getAt i l
   ety <- telInst tel i l
-  (dc0, e', chTy) <- rePlaceE sig ctx step d p ety e Nothing
+  (dc0, e', chTy) <- rePlaceE sig ctx step d p ety e Nothing Nothing
   dc <- eqAtLem sig ctx dc0 chTy ety
   dSig <- reQSig sig ctx sg
   ds <- traverse (\(j, ej) =>
@@ -2691,14 +3304,10 @@ headTag (QCtor _ k _) = "qctor" ++ show k
 headTag (Out _) = "out"
 headTag _ = "other"
 
-||| Every well-typed instantiation of a step's ∀-lemma over a
-||| candidate pool: the licensed proof's application spine (PiApp
-||| tower or signature spine) re-built at searched arguments,
-||| type-filtered along the Π tower or telescope; each result is the
-||| reflected equation (conjugated to nf) with its endpoints and
-||| type.
-lemmaInsts : Sig -> Ctx -> Step -> Nat -> List Elem -> List (Deriv, Elem, Elem, Ty, Elem)
-lemmaInsts sig ctx step d pool0 =
+-- (see the declaration above lemBridgeT for the contract: recorded
+-- spine re-built at searched arguments type-filtered along the
+-- telescope, plus match-directed candidates read off the pair)
+lemmaInsts sig ctx step d pool0 (xN, yN) =
   let pool = nub pool0 in
   case step.lic of
     LProof p =>
@@ -2725,7 +3334,7 @@ lemmaInsts sig ctx step d pool0 =
         Nothing => []
         Just (spineTys, rebuild, arity) =>
           mapMaybe (instOf rebuild)
-            (take 24 (tuples spineTys rebuild pool arity []))
+            (nub (matchCands ++ take 24 (tuples spineTys rebuild pool arity [])))
     _ => []
  where
   peel : Elem -> List Elem -> (Elem, List Elem)
@@ -2735,6 +3344,53 @@ lemmaInsts sig ctx step d pool0 =
   applyE : Elem -> List Elem -> Elem
   applyE h [] = h
   applyE h (u :: rest) = applyE (PiApp h u) rest
+
+  -- ===== match-directed instantiation =====
+  -- Enumeration cannot reach a 3-argument tuple through an untyped
+  -- ℕ pool; but an instantiation's endpoints must BE the pair, so
+  -- first-order matching of the lemma's nf'd statement sides against
+  -- the pair reads the arguments off directly. Wrong or partial
+  -- matches are harmless: every candidate still rides instOf and the
+  -- caller's exact-endpoint check.
+
+  matchPair : Nat -> Elem -> Elem -> Maybe (List Elem)
+  matchPair n pat tgt = matchStTuple n pat tgt
+
+  -- the ∀-arguments arrive as signature-context entries (SigVar's
+  -- environment) AND as Π-binders (the proof applied by PiApp);
+  -- both count as pattern variables, innermost = the last argument
+  stripPis : Ty -> (Nat, Ty)
+  stripPis (Ty.PiTy _ b) = let (k, r) = stripPis b in (S k, r)
+  stripPis t = (Z, t)
+
+  matchCands : List (List Elem)
+  matchCands =
+    case (d, step.lic) of
+      (Z, LProof p0) =>
+        case peel p0 [] of
+          (Elem.SigVar nm es, aps) =>
+            let mDty = the (Maybe (Nat, Ty)) $ case sigLookup nm sig of
+                         Just (SigDef dctx _ _ dty) => Just (length (toList dctx), dty)
+                         Just (SigDecl dctx _ dty) => Just (length (toList dctx), dty)
+                         _ => Nothing in
+            case mDty of
+              Just (n0, dty) =>
+                let True = length (toList es) == n0
+                      | False => the (List (List Elem)) []
+                    (nPi, body) = stripPis dty
+                    True = nPi == length aps
+                      | False => the (List (List Elem)) []
+                    n = n0 + nPi in
+                case body of
+                  Prf (Elem.EqTy lhs rhs _) =>
+                    let lhsN = fromMaybe lhs (nfE sig lhs)
+                        rhsN = fromMaybe rhs (nfE sig rhs) in
+                    nub (mapMaybe (\(pt, tg) => matchPair n pt tg)
+                           [(lhsN, xN), (lhsN, yN), (rhsN, xN), (rhsN, yN)])
+                  _ => []
+              _ => []
+          _ => []
+      _ => []
 
   slotTy : List Ty -> (List Elem -> Maybe Elem) -> List Elem -> Maybe Ty
   slotTy spineTys rebuild acc =
@@ -2776,14 +3432,66 @@ lemmaInsts sig ctx step d pool0 =
                 (DElTrans dR (DNfExpand (DPresupElR dR)))
     pure (dRN, leN, reN, t, p')
 
+sigLawInsts sig ctx (xa, ya) = concatMap tryEntry (toList sig)
+ where
+  stripPis : Ty -> (Nat, Ty)
+  stripPis (Ty.PiTy _ b) = let (k, r) = stripPis b in (S k, r)
+  stripPis t = (Z, t)
+
+  mk : SigIdentifier -> List Elem -> Maybe (Elem, Elem, Deriv)
+  mk nm args = do
+    let pf = foldl PiApp (Elem.SigVar nm [<]) args
+    (dp, pty) <- reInfer sig ctx pf emptySkel
+    ptyN <- nfT sig pty
+    let dp' = if pty == ptyN
+                then dp
+                else DElTyCoe (DNfExpandTy (DPresupElTy dp)) dp
+    let Prf (Elem.EqTy le re _) = ptyN
+      | _ => Nothing
+    let dR = DElReflect dp'
+    leN <- nfE sig le
+    reN <- nfE sig re
+    pure (leN, reN,
+          DElTrans (DElSym (DNfExpand (DPresupElL dR)))
+            (DElTrans dR (DNfExpand (DPresupElR dR))))
+
+  tryEntry : SigEntry -> List (Elem, Elem, Deriv)
+  tryEntry (SigDef [<] nm _ dty) =
+    let (nPi, body) = stripPis dty in
+    case body of
+      Prf (Elem.EqTy lhs rhs _) =>
+        let lhsN = fromMaybe lhs (nfE sig lhs)
+            rhsN = fromMaybe rhs (nfE sig rhs) in
+        mapMaybe (mk nm)
+          (nub (mapMaybe (\(pt, tg) => matchStTuple nPi pt tg)
+                  [(lhsN, xa), (lhsN, ya), (rhsN, xa), (rhsN, ya)]))
+      _ => []
+  tryEntry _ = []
+
 lemmaLeafB : Sig -> Ctx -> Step -> Nat -> Elem -> Elem -> Maybe (Deriv, Ty)
 
 ||| A step's ∀-lemma re-instantiated to MATCH a mismatched pair.
 lemmaLeaf : Sig -> Ctx -> Step -> Nat -> Elem -> Elem -> Maybe (Deriv, Ty)
 lemmaLeaf sig ctx step d x y =
+  (if reconDebug
+     then trace "lemma: try \{licHead} on \{show x} / \{show y}" (Just ())
+     else Just ()) >>= \_ =>
   withMemo memoLL "\{show (length (toList ctx))}|LL|\{show d}|\{lk}|\{show x}=\{show y}"
     (lemmaLeafB sig ctx step d x y)
  where
+  hd : Elem -> Elem
+  hd (PiApp f _) = hd f
+  hd e = e
+
+  licHead : String
+  licHead = case step.lic of
+              LProof p0 =>
+                (case hd p0 of
+                   Elem.SigVar nm _ => nm
+                   _ => "other")
+              LBeta => "beta"
+              LPath _ _ _ => "path"
+
   lk : String
   lk = show step.path ++ show step.flip ++
        (case step.lic of
@@ -2794,15 +3502,25 @@ lemmaLeaf sig ctx step d x y =
 lemmaLeafB sig ctx step d x y = do
   -- enumerate only when the pair's rigid heads overlap the
   -- license's — typed enumeration on a hopeless pair is what blows
-  -- the budget
-  (_, le, re, _) <- reLicensed sig ctx step d
-  let licTags = filter (/= "var") [headTag le, headTag re]
-  let pairTags = filter (/= "var") [headTag x, headTag y]
-  let True = any (\t => elem t licTags) pairTags
-             || (null pairTags && null licTags)
+  -- the budget. The recorded instance may not SPEAK this context at
+  -- all (a type-expansion step recorded over the statement's
+  -- binders): then nothing gates, and the match-directed path — which
+  -- reads its arguments off the pair itself — still runs.
+  let True = case reLicensed sig ctx step d of
+               Nothing => True
+               Just (_, le, re, _) =>
+                 -- tag at nf: the license may expose a β-redex (the
+                 -- nf'd law function applied) whose contraction is
+                 -- the pair's rigid head
+                 let licTags = filter (/= "var")
+                                 [headTag (fromMaybe le (nfE sig le)),
+                                  headTag (fromMaybe re (nfE sig re))]
+                     pairTags = filter (/= "var") [headTag x, headTag y] in
+                 any (\t => elem t licTags) pairTags
+                 || (null pairTags && null licTags)
     | False => Nothing
-  xN <- nfE sig x
-  yN <- nfE sig y
+  xN <- dbg "lemma: nfE x dead" (nfE sig x)
+  yN <- dbg "lemma: nfE y dead" (nfE sig y)
   -- ∀-re-instantiation pays off only on SMALL pairs (index laws);
   -- a tower pair costs its enumeration at every walk leaf
   let False = candPosOver 60 xN || candPosOver 60 yN
@@ -2816,13 +3534,15 @@ lemmaLeafB sig ctx step d x y = do
   let pool = filter relevant
                (map CtxVar [0 .. minus (length (toList ctx)) 1]
                 ++ subterms 3 x ++ subterms 3 y)
-  pick xN yN (lemmaInsts sig ctx step d pool)
+  pick xN yN (lemmaInsts sig ctx step d pool (xN, yN))
  where
   pick : Elem -> Elem -> List (Deriv, Elem, Elem, Ty, Elem) -> Maybe (Deriv, Ty)
   pick xN yN [] = dbg "lemma: none matched for \{show xN} / \{show yN}" Nothing
   pick xN yN ((dEq, leN, reN, t, _) :: rest) =
-    if leN == xN && reN == yN then Just (dEq, t)
-      else if leN == yN && reN == xN then Just (DElSym dEq, t)
+    if leN == xN && reN == yN
+      then (if reconDebug then trace "lemma: MATCHED \{show xN} / \{show yN}" (Just (dEq, t)) else Just (dEq, t))
+      else if leN == yN && reN == xN
+        then (if reconDebug then trace "lemma: MATCHED (sym) \{show xN} / \{show yN}" (Just (DElSym dEq, t)) else Just (DElSym dEq, t))
       else pick xN yN rest
 
 ||| The HYPOTHESIS-SENSITIVE TYPE BRIDGE: a placement at a dependent
@@ -3114,7 +3834,10 @@ reBridgeTSearchN (S fuel) sig ctx stp d a b =
     let pool = nub (filter natish
                       (map CtxVar [0 .. minus (length (toList ctx)) 1]
                        ++ subterms 4 x))
-    firstProp x tgt (take 12 (lemmaInsts sig ctx stp d pool))
+    let tgtCode = the Elem $ case tgt of
+                    El y => y
+                    _ => x
+    firstProp x tgt (take 12 (lemmaInsts sig ctx stp d pool (x, tgtCode)))
 
 reBridgeTSearch sig ctx stp d a b =
   withMemo memoBr "\{show (length (toList ctx))}|BR|\{show d}|\{licKey}|\{show a}=\{show b}"
@@ -3131,8 +3854,8 @@ reBridgeTSearch sig ctx stp d a b =
 ||| rolling state carries a COMPACT typing derivation of cur (the
 ||| last link's right presupposition) — embedding the whole chain in
 ||| each link's premise duplicates it exponentially at replay.
-stepChainE : Sig -> Ctx -> Bool -> List Step -> Ty -> (Deriv, Deriv, Elem) -> Step -> Maybe (Deriv, Deriv, Elem)
-stepChainE sig ctx positional allSteps ty (chain, dCur, cur) step =
+stepChainE : Sig -> Ctx -> Bool -> List Step -> Maybe (Ty, ECert) -> Ty -> (Deriv, Deriv, Elem) -> Step -> Maybe (Deriv, Deriv, Elem)
+stepChainE sig ctx positional allSteps mTyEx ty (chain, dCur, cur) step =
   case step.lic of
     -- a positional exposure: ONE ≜ contraction at the recorded path,
     -- a beta-at link — the spelling stays exact and typing flows by
@@ -3141,8 +3864,23 @@ stepChainE sig ctx positional allSteps ty (chain, dCur, cur) step =
       cur' <- dbg "posLB: no redex at \{show step.path} in \{show cur}"
                 (contractAtE sig step.path cur)
       let link = DBetaAt step.path dCur
+      -- the structural witness contracts IN STEP with the spelling:
+      -- subject reduction run forward on the derivation (a failure
+      -- just drops the witness — placements fall back to
+      -- reconstruction, never the chain)
+      let w' = readChainWit () >>= stepTypedE sig step.path (Just cur)
+      _ <- setChainWit (if reconDebug then trace "wit: step \{show step.path} -> \{show (isJust w')}" w' else w')
       pure (DElTrans chain link, DPresupElR link, cur')
-    _ => if positional then posRoute <|> nfRoute else nfRoute
+    _ => do
+      (ch', dCur', cur') <- the (Maybe (Deriv, Deriv, Elem))
+                              (if positional then posRoute <|> nfRoute else nfRoute)
+      -- a lemma step rewrote the spelling out from under the
+      -- witness: the chain's own presupposed typing of the placed
+      -- spelling IS the new witness — the placement's congruence
+      -- skeleton is walkable through the presup-projection views
+      let w' = Just dCur' <|> elWitFor sig ctx cur' <|> plainWit sig ctx cur'
+      _ <- setChainWit (if reconDebug then trace "wit: relaid \{maybe "none" dTag w'}" w' else w')
+      pure (ch', dCur', cur')
  where
   -- the dependent shift may be imposed by ANY of the certificate's
   -- licenses (an index law travels as its own step): try each
@@ -3173,9 +3911,9 @@ stepChainE sig ctx positional allSteps ty (chain, dCur, cur) step =
       then Just dPl
       else do
         let False = tySizeFuel 601 [] plTy == 0 || tySizeFuel 601 [] ty == 0
-          | True => Nothing
-        pN <- nfT sig plTy
-        tN <- nfT sig ty
+          | True => dbg "wit: brTo size gate" Nothing
+        pN <- dbg "wit: brTo nf plTy" (nfT sig plTy)
+        tN <- dbg "wit: brTo nf ty" (nfT sig ty)
         let dPlTy = DPresupElTy (DPresupElL dPl)          -- ⊢ plTy type
         let dTy = DPresupElTy dCur                        -- ⊢ ty type
         if pN == tN
@@ -3193,8 +3931,32 @@ stepChainE sig ctx positional allSteps ty (chain, dCur, cur) step =
                        -- differing by index laws meet by recorded
                        -- pool instances — never the proposing search
                        let False = tySizeFuel 601 [] pN == 0
-                         | True => Nothing
-                       lemBridgeT sig ctx (step :: allSteps) 3 pN tN
+                         | True => dbg "wit: brTo nf size gate" Nothing
+                       -- recorded instances may not COMPOSE to the
+                       -- shift (an index law instance at freshly
+                       -- combined arguments): the proposing search is
+                       -- affordable exactly when both nf'd spellings
+                       -- stayed small
+                       dbg "wit: brTo pool bridge \{show pN} VS \{show tN}"
+                         (lemBridgeT sig ctx (step :: allSteps) 10 pN tN
+                          <|> (do let False = tySizeFuel 301 [] pN == 0 || tySizeFuel 301 [] tN == 0
+                                    | True => Nothing
+                                  -- the fallback is one bounded pass
+                                  -- over small nf'd spellings; arm it
+                                  -- even when the chain has drained
+                                  -- the equation's allowance
+                                  _ <- resetBudget 50000
+                                  anyLic (\st => reBridgeT sig ctx (Just st) 0 pN tN))
+                          -- the recorded type-expansion IS the shift:
+                          -- replay it as the bridge (ty rides to its
+                          -- expanded spelling, which must meet the
+                          -- placement's at nf)
+                          <|> (do (tyX, certT) <- mTyEx
+                                  _ <- resetBudget 50000
+                                  (dX, tyR) <- reEqTyReach sig ctx certT ty tyX
+                                  let True = tyR == pN
+                                    | False => dbg "wit: brTo tyEx reach \{show tyR} /= \{show pN}" Nothing
+                                  pure (DTyTrans (DTySym dX) (DNfExpandTy dTy))))
             let atN = DElEqTyCoe dBr dPlN
             pure (DElEqTyCoe (DTySym (DNfExpandTy dTy)) atN)
 
@@ -3204,7 +3966,7 @@ stepChainE sig ctx positional allSteps ty (chain, dCur, cur) step =
   posRoute = do
     (dPl, cur', plTy) <- dbg "posPL: place \{show step.path} in \{show cur}"
                            (rePlaceE sig ctx step 0 step.path ty cur
-                              (Just dCur))
+                              (Just dCur) (readChainWit ()))
     dPl' <- dbg "posBR: \{show plTy} vs \{show ty}" (bridgeTo False dPl plTy)
     pure (DElTrans chain dPl', DPresupElR dPl', cur')
 
@@ -3225,7 +3987,7 @@ stepChainE sig ctx positional allSteps ty (chain, dCur, cur) step =
                             Just (DElTrans chain link, DPresupElR link)
     (dPl, cur', plTy) <- dbg "step: place \{show step.path} in \{show curN}"
                            (rePlaceE sig ctx step 0 step.path ty curN
-                              (Just dCur2))
+                              (Just dCur2) Nothing)
     dPl' <- bridgeTo True dPl plTy
     pure (DElTrans chain2 dPl', DPresupElR dPl', cur')
 
@@ -3347,13 +4109,18 @@ reEqStar sig ctx cert l r ty ends =
           withMemo memoResc "\{show ctx}|RS\{show (maybe False (const True) ends)}|\{show l}=\{show r}:\{show ty}" $ do
             pl <- posSide sig ctx l (filter (.onLhs) cert.steps)
             pr <- posSide sig ctx r (filter (not . (.onLhs)) cert.steps)
+            -- the re-scripted replay is one bounded pass over its own
+            -- exposures: it gets the same allowance a fresh equation
+            -- birth would, not the drained remainder of the item's
             dbg "resc: scripted \{show (length (pl ++ pr))} but the replay declined for \{show l}"
-              (reEqEndsGo sig ctx ({ pos := pl ++ pr } cert) l r ty ends))
+              (resetBudget 100000 >>= \_ =>
+               reEqEndsGo sig ctx ({ pos := pl ++ pr } cert) l r ty ends))
 
 reEqEndsGo sig ctx cert l r ty ends =
   lookupEqDeriv sig ctx l r ty <|> reEqEndsGoB sig ctx cert l r ty ends
 
 reEqEndsGoB sig ctx (MkECertF tyEx steps0 final posSteps) l r ty ends =
+  restoreWitAfter (readChainWit ()) $
   setLicPool (steps0 ++ posSteps ++ (case tyEx of
                                        Just (_, certT) => certT.steps
                                        Nothing => [])) >>= \_ =>
@@ -3371,8 +4138,17 @@ reEqEndsGoB sig ctx (MkECertF tyEx steps0 final posSteps) l r ty ends =
                     Just (tyR, Just dBr)
   dl0 <- dbg "req: endpoint L \{show l} AT \{show ty'}" (endpoint l ty' pre (fst <$> ends))
   dr0 <- dbg "req: endpoint R \{show r} AT \{show ty'}" (endpoint r ty' pre (snd <$> ends))
+  -- the side's ENDPOINT derivation is the natural witness — it is in
+  -- hand and typically structural (reCheck emits the spine's nodes);
+  -- the raw by-term store entry is preferred where present (born
+  -- unshared, so its premises conclude standalone)
+  let wl = elWitFor sig ctx l <|> plainWit sig ctx l <|> Just dl0
+  _ <- setChainWit (if reconDebug then trace "wit: seed L \{maybe "none" dTag wl} store \{show (isJust (elWitFor sig ctx l))} plain \{show (isJust (plainWit sig ctx l))}" wl else wl)
   (chL, _, curL) <- dbg "req: chain L" (goSide ty' (DElRefl dl0, dl0, l) (filter (.onLhs) steps))
+  let wr = elWitFor sig ctx r <|> plainWit sig ctx r <|> Just dr0
+  _ <- setChainWit (if reconDebug then trace "wit: seed R \{maybe "none" dTag wr}" wr else wr)
   (chR, _, curR) <- dbg "req: chain R" (goSide ty' (DElRefl dr0, dr0, r) (filter (not . (.onLhs)) steps))
+  _ <- setChainWit Nothing
   mid <- dbg "req: close, curL \{show curL} curR \{show curR}" (closeE sig ctx ty' chL curL chR curR final)
   let whole = DElTrans chL (DElTrans mid (DElSym chR))
   pure $ case pre of
@@ -3503,7 +4279,7 @@ reEqEndsGoB sig ctx (MkECertF tyEx steps0 final posSteps) l r ty ends =
   goSide : Ty -> (Deriv, Deriv, Elem) -> List Step -> Maybe (Deriv, Deriv, Elem)
   goSide t st [] = Just st
   goSide t st (stp :: rest) = do
-    st' <- stepChainE sig ctx (not (null posSteps)) licPool t st stp
+    st' <- stepChainE sig ctx (not (null posSteps)) licPool tyEx t st stp
     goSide t st' rest
 
 reEqTy sig ctx cert a b = reEqTyEnds sig ctx cert a b (Nothing, Nothing)
@@ -4051,6 +4827,35 @@ birthTyEqDeriv sig ctx cert a b = unsafePerformIO $ do
       modifyIORef storedTyEq (\m => insert h1 ((h2, d) :: fromMaybe [] (lookup h1 m)) m)
       pure (if reconDebug then trace "eq: ty born \{show h1}" cert else cert)
     Nothing => pure cert
+
+||| A SMALL definition body re-derived share-free: the accepted
+||| emission wraps in DShare bindings the walk cannot see through,
+||| and a SigVar unfold splices the recorded derivation into witness
+||| walks — worth one plain re-emission for a body this size.
+export
+plainDefDeriv : Sig -> KDefArt -> Maybe Deriv
+plainDefDeriv sig art = unsafePerformIO $ do
+  let True = not (candPosOver 300 art.body)
+    | False => pure Nothing
+  was <- readIORef sharingOn
+  spent <- readIORef workBudget
+  writeIORef sharingOn False
+  writeIORef workBudget (max spent 50000)
+  let r = the (Maybe Deriv) $ do
+            dT <- reTy sig [<] art.dty art.dtySkel
+            emitBody sig [<] art.body art.dty art.bodySkel dT
+  let r' = if reconDebug
+             then trace "wit: plainDef \{show (isJust r)} for \{show art.body}" r
+             else r
+  case r' of
+    Just dw => do
+      writeIORef sharingOn was
+      writeIORef workBudget spent
+      pure (Just dw)
+    Nothing => do
+      writeIORef sharingOn was
+      writeIORef workBudget spent
+      pure Nothing
 
 ||| A def item's two derivations (the type's formation and the
 ||| body's typing). Nothing = emission does not cover the item (the

--- a/src/idris/Nova/Kernel/Reconstruct.idr
+++ b/src/idris/Nova/Kernel/Reconstruct.idr
@@ -492,9 +492,8 @@ withMemo ref k act = unsafePerformIO $ do
       modifyIORef ref (insert k v)
       pure v
 
-%noinline
-clearMemos : () -> Maybe ()
-clearMemos _ = unsafePerformIO $ do
+resetMemosIO : IO ()
+resetMemosIO = do
   writeIORef workBudget 400000
   writeIORef memoNfE empty
   writeIORef memoNfT empty
@@ -505,6 +504,25 @@ clearMemos _ = unsafePerformIO $ do
   writeIORef memoBr empty
   writeIORef memoLL empty
   writeIORef memoLB empty
+
+||| Run an emission under a fresh budget and cold memo tables: the
+||| outcome becomes a function of the ARGUMENTS alone, so callers may
+||| gate on a fingerprint of them (the mirror's gate assumed this and
+||| was reverted when leftover budget and stale entries falsified
+||| it). The resets are sequenced IO and the payload is forced inside
+||| them — dataflow-forced, since erased bindings and identical-branch
+||| cases both taught us they silently vanish.
+export
+%noinline
+withFreshEmission : Lazy a -> a
+withFreshEmission act = unsafePerformIO $ do
+  resetMemosIO
+  pure (force act)
+
+%noinline
+clearMemos : () -> Maybe ()
+clearMemos _ = unsafePerformIO $ do
+  resetMemosIO
   pure (Just ())
 
 nfE : Sig -> Elem -> Maybe Elem

--- a/src/idris/Nova/Kernel/Reconstruct.idr
+++ b/src/idris/Nova/Kernel/Reconstruct.idr
@@ -378,6 +378,39 @@ concludesEq sig ctx d l r ty =
 storedTyEq : IORef (SortedMap Integer (List (Integer, Deriv)))
 storedTyEq = mkTable 11
 
+-- typing judgments the ELABORATOR knew: the universal interface for
+-- ported routes — any elaboration point holding a derivation of
+-- Γ ⊦ t : A stores it here, and reconstruction becomes lookup-first
+%noinline
+storedEl : IORef (SortedMap Integer (List (Integer, Deriv)))
+storedEl = mkTable 12
+
+elKey : Ctx -> Elem -> Ty -> (Integer, Integer)
+elKey ctx e ty =
+  ( hashT 33 (hashE 33 (hashCtx 33 ctx) e) ty
+  , hashT 131 (hashE 131 (hashCtx 131 ctx) e) ty )
+
+concludesEl : Sig -> Ctx -> Deriv -> Elem -> Ty -> Bool
+concludesEl sig ctx d e ty =
+  case runKM (conclude sig ctx d) fuelR of
+    Right (JEl e' ty', _) => e' == e && ty' == ty
+    _ => False
+
+lookupElDeriv : Sig -> Ctx -> Elem -> Ty -> Maybe Deriv
+lookupElDeriv sig ctx e ty = unsafePerformIO $ do
+  m <- readIORef storedEl
+  let (h1, h2) = elKey ctx e ty
+  case lookup h2 (fromMaybe [] (lookup h1 m)) of
+    Just d => pure (if concludesEl sig ctx d e ty
+                      then (if reconDebug then trace "el: stored deriv used" (Just d) else Just d)
+                      else (if reconDebug then trace "el: stored deriv stale" Nothing else Nothing))
+    Nothing => pure Nothing
+
+storeElDeriv : Ctx -> Elem -> Ty -> Deriv -> IO ()
+storeElDeriv ctx e ty d = do
+  let (h1, h2) = elKey ctx e ty
+  modifyIORef storedEl (\m => insert h1 ((h2, d) :: fromMaybe [] (lookup h1 m)) m)
+
 tyEqKey : Ctx -> Ty -> Ty -> (Integer, Integer)
 tyEqKey ctx a b =
   ( hashT 33 (hashT 33 (hashCtx 33 ctx) a) b
@@ -1001,9 +1034,12 @@ mutual
   reCheck sig ctx e ty (Nd [] []) = do
     let True = spendOk ()
       | False => Nothing
+    let Nothing = lookupElDeriv sig ctx e ty
+      | Just d => Just d
     withMemoH memoChk (hashT 33 (hashE 33 (hashCtx 33 ctx) e) ty) (hashT 131 (hashE 131 (hashCtx 131 ctx) e) ty)
       (reCheckB sig ctx e ty emptySkel)
-  reCheck sig ctx e ty sk = reCheckB sig ctx e ty sk
+  reCheck sig ctx e ty sk =
+    lookupElDeriv sig ctx e ty <|> reCheckB sig ctx e ty sk
 
   reCheckB : Sig -> Ctx -> Elem -> Ty -> Skel -> Maybe Deriv
   reCheckB sig ctx e ty sk =
@@ -1048,9 +1084,11 @@ mutual
     df <- reCheckF sig (ctx :< a) f b (childAt 0 sk) (DInvPiCod dF)
     pure (DElPiI da df)
   reCheckF sig ctx Star ty sk dF =
-    -- the inversion route FIRST: the plain route re-derives the
+    -- a stored derivation first (the elaborator knew this typing),
+    -- then the inversion route: the plain route re-derives the
     -- goal's endpoints from their spellings, and on normalized
     -- eliminator instances that search is unbounded
+    lookupElDeriv sig ctx Star ty <|>
     (case (payload pRefl sk, ty) of
           (Just cert, Prf (Elem.EqTy l r t)) =>
             dbg "star-inv: \{show l} EQ \{show r} AT \{show t}"
@@ -1171,6 +1209,7 @@ mutual
     dt <- reCheck sig ctx t Ty.ZeroTy (childAt 0 sk)
     pure (DElZeroE dA dt)
   reCheckGo sig ctx Star ty sk =
+    lookupElDeriv sig ctx Star ty <|>
     case payload pRefl sk of
       Just cert =>
         case ty of
@@ -3475,6 +3514,10 @@ birthEqDeriv sig ctx cert l r ty = unsafePerformIO $ do
     Just d => do
       let (h1, h2) = eqKey ctx l r ty
       modifyIORef storedEq (\m => insert h1 ((h2, d) :: fromMaybe [] (lookup h1 m)) m)
+      -- the ⋆ inhabiting this equation is typed by one el-eq-i node:
+      -- the first entry of the typing store, and the reason the
+      -- seat's star routes stop being special
+      _ <- storeElDeriv ctx Star (Prf (Elem.EqTy l r ty)) (DElEqI d)
       pure (if reconDebug then trace "eq: born \{show h1}" cert else cert)
     Nothing => pure cert
 

--- a/src/idris/Nova/Kernel/Reconstruct.idr
+++ b/src/idris/Nova/Kernel/Reconstruct.idr
@@ -651,6 +651,42 @@ nfT sig t = do
        Right (x, _) => Just x
        Left _ => Nothing)
 
+-- formations the ELABORATOR knew (Γ ⊦ A type)
+%noinline
+storedTy2 : IORef (SortedMap Integer (List (Integer, Deriv)))
+storedTy2 = mkTable 18
+
+fmKey : Ctx -> Ty -> (Integer, Integer)
+fmKey ctx t = (hashT 33 (hashCtx 33 ctx) t, hashT 131 (hashCtx 131 ctx) t)
+
+concludesTy : Sig -> Ctx -> Deriv -> Ty -> Bool
+concludesTy sig ctx d t =
+  case runKM (conclude [] sig ctx d) fuelR of
+    Right (JTy t', _) => t' == t
+    _ => False
+
+lookupTyDeriv : Sig -> Ctx -> Ty -> Maybe Deriv
+lookupTyDeriv sig ctx t = unsafePerformIO $ do
+  m <- readIORef storedTy2
+  let (h1, h2) = fmKey ctx t
+  case lookup h2 (fromMaybe [] (lookup h1 m)) of
+    Just d =>
+      if isValidated (h1 + 127, h2)
+        then Just <$> serveShared (h1 + 5, h2) ctx d
+        else if concludesTy sig ctx d t
+          then do
+            _ <- markValidated (h1 + 127, h2)
+            d' <- serveShared (h1 + 5, h2) ctx d
+            pure (if reconDebug then trace "ty: stored formation used" (Just d') else Just d')
+          else pure Nothing
+    Nothing => pure Nothing
+
+%noinline
+storeTyDeriv : Ctx -> Ty -> Deriv -> IO ()
+storeTyDeriv ctx t d = do
+  let (h1, h2) = fmKey ctx t
+  modifyIORef storedTy2 (\m => insert h1 ((h2, d) :: fromMaybe [] (lookup h1 m)) m)
+
 ||| The FLEXIBLE lookup: exact spelling first; else any stored entry
 ||| for the same term whose type is nf-equal to the asked one, served
 ||| through a coercion — the stored side's formation comes free by
@@ -1240,11 +1276,17 @@ mutual
   ||| INVERSION delivers them from the threaded derivation.
   export
   reCheckF : Sig -> Ctx -> Elem -> Ty -> Skel -> Deriv -> Maybe Deriv
-  reCheckF sig ctx (PiIntro f) (Ty.PiTy a b) sk dF = do
+  reCheckF sig ctx e ty sk dF =
+    -- a stored typing at the OUTERMOST node serves the whole subtree
+    -- in one citation; the structural descent is the fallback
+    lookupElDerivAt sig ctx e ty dF <|> reCheckFGo sig ctx e ty sk dF
+
+  reCheckFGo : Sig -> Ctx -> Elem -> Ty -> Skel -> Deriv -> Maybe Deriv
+  reCheckFGo sig ctx (PiIntro f) (Ty.PiTy a b) sk dF = do
     da <- reTy sig ctx a emptySkel <|> Just (DInvPiDom dF)
     df <- reCheckF sig (ctx :< a) f b (childAt 0 sk) (DInvPiCod dF)
     pure (DElPiI da df)
-  reCheckF sig ctx Star ty sk dF =
+  reCheckFGo sig ctx Star ty sk dF =
     -- a stored derivation first (the elaborator knew this typing),
     -- then the inversion route: the plain route re-derives the
     -- goal's endpoints from their spellings, and on normalized
@@ -1268,9 +1310,8 @@ mutual
             pure (DElTyCoe (DTySym (DNfExpandTy dF)) d0)
           _ => Nothing)
     <|> reCheck sig ctx Star ty sk
-  reCheckF sig ctx e ty sk dF =
-    lookupElDerivAt sig ctx e ty dF
-    <|> reCheck sig ctx e ty sk
+  reCheckFGo sig ctx e ty sk dF =
+    reCheck sig ctx e ty sk
     <|> (case payload pSw sk of
           Just cert => do
             (d, ity) <- reInfer sig ctx e (dropP isSw sk)
@@ -3683,6 +3724,18 @@ birthEqDeriv sig ctx cert l r ty = unsafePerformIO $ do
       pure (if reconDebug then trace "eq: born \{show h1}" cert else cert)
     Nothing => pure cert
 
+-- birth adapters: formation from the store else re-derivation;
+-- checking exact-else-FLEX (the formation store supplies the drift
+-- coercion's missing premise) else re-derivation
+fmF : Sig -> Ctx -> Ty -> Maybe Deriv
+fmF sig cx t = lookupTyDeriv sig cx t <|> reTy sig cx t emptySkel
+
+chkF : Sig -> Ctx -> Elem -> Ty -> Maybe Deriv
+chkF sig cx e t =
+  (do dF <- lookupTyDeriv sig cx t
+      lookupElDerivAt sig cx e t dF)
+  <|> reCheck sig cx e t emptySkel
+
 ||| An ℕ-elim's typing, born where the elaborator still HOLDS the
 ||| motive (core syntax drops it — that loss is what the seat's
 ||| motive guessing exists to reconstruct). Premises come through
@@ -3695,11 +3748,11 @@ birthNatE : Sig -> Ctx -> Ty -> Elem -> Elem -> Elem -> Elem
 birthNatE sig ctx mot z s t = unsafePerformIO $ do
   _ <- writeIORef workBudget 100000
   let concl = substTy mot (Ext Id t)
-  let mder = do dmot <- reTy sig (ctx :< Ty.NatTy) mot emptySkel
-                dz <- reCheck sig ctx z (substTy mot (Ext Id NatIntro0)) emptySkel
-                ds <- reCheck sig (ctx :< Ty.NatTy :< mot) s
-                        (substTy mot (Chain (Ext Wk (NatIntro1 (CtxVar 0))) Wk)) emptySkel
-                dt <- reCheck sig ctx t Ty.NatTy emptySkel
+  let mder = do dmot <- fmF sig (ctx :< Ty.NatTy) mot
+                dz <- chkF sig ctx z (substTy mot (Ext Id NatIntro0))
+                ds <- chkF sig (ctx :< Ty.NatTy :< mot) s
+                        (substTy mot (Chain (Ext Wk (NatIntro1 (CtxVar 0))) Wk))
+                dt <- chkF sig ctx t Ty.NatTy
                 pure (DElNatE dmot dz ds dt)
   case mder of
     Just d => do
@@ -3751,6 +3804,31 @@ birthQuotE sig ctx a rel mot f q wd = unsafePerformIO $ do
       pure (if reconDebug then trace "el: quotE born" (QuotElim f q) else QuotElim f q)
     Nothing => pure (QuotElim f q)
 
+||| A formation's derivation, born at the elaboration clause that
+||| composed the type: one node over the components' formations.
+export
+%noinline
+birthTy : Sig -> Ctx -> Ty -> Ty
+birthTy sig ctx t = unsafePerformIO $ do
+  let False = tySizeFuel 4001 [] t == 0
+    | True => pure t
+  _ <- writeIORef workBudget 600
+  let mder = the (Maybe Deriv) $ case t of
+        Ty.PiTy a b => [| DTyPi (fmF sig ctx a) (fmF sig (ctx :< a) b) |]
+        Ty.SigmaTy a b => [| DTySigma (fmF sig ctx a) (fmF sig (ctx :< a) b) |]
+        Ty.SumTy a b => [| DTySum (fmF sig ctx a) (fmF sig ctx b) |]
+        El e => DTyEl <$> chkF sig ctx e Ty.UniverseTy
+        Prf e => DTyPrf <$> chkF sig ctx e Ty.PropTy
+        Ty.Quotient a r =>
+          [| DTyQuot (fmF sig ctx a)
+                     (chkF sig (ctx :< a :< substTy a Wk) r Ty.PropTy) |]
+        _ => Nothing
+  case mder of
+    Just d => do
+      _ <- storeTyDeriv ctx t d
+      pure (if reconDebug then trace "ty: formation born" t else t)
+    Nothing => pure t
+
 ||| A λ's typing at its checked Π (el-pi-i): the body's judgment
 ||| composes from the store as its own nodes birth.
 export
@@ -3763,8 +3841,8 @@ birthPiI sig ctx a b body = unsafePerformIO $ do
   let False = candPosOver 4000 body
     | True => pure (PiIntro body)
   _ <- writeIORef workBudget 600
-  let mder = do da <- reTy sig ctx a emptySkel
-                db <- reCheck sig (ctx :< a) body b emptySkel
+  let mder = do da <- fmF sig ctx a
+                db <- chkF sig (ctx :< a) body b
                 pure (DElPiI da db)
   case mder of
     Just d => do
@@ -3783,9 +3861,9 @@ birthPiE sig ctx a b f e = unsafePerformIO $ do
   -- birth cheap and a reconstruction-shaped one bail immediately
   _ <- writeIORef workBudget 600
   let concl = substTy b (Ext Id e)
-  let mder = do df <- reCheck sig ctx f (Ty.PiTy a b) emptySkel
-                de <- reCheck sig ctx e a emptySkel
-                db <- reTy sig (ctx :< a) b emptySkel
+  let mder = do df <- chkF sig ctx f (Ty.PiTy a b)
+                de <- chkF sig ctx e a
+                db <- fmF sig (ctx :< a) b
                 pure (DElPiE df de db)
   case mder of
     Just d => do

--- a/src/idris/Nova/Kernel/Reconstruct.idr
+++ b/src/idris/Nova/Kernel/Reconstruct.idr
@@ -3757,10 +3757,10 @@ export
 %noinline
 birthPiI : Sig -> Ctx -> Ty -> Ty -> Elem -> Elem
 birthPiI sig ctx a b body = unsafePerformIO $ do
-  -- keying is structural: hashing every node's whole subtree is
-  -- quadratic over an item — only small nodes birth (they carry the
-  -- consumption anyway)
-  let False = candPosOver 150 body
+  -- the budget bounds the adapters; the size bound only caps the
+  -- keying cost, and the top nodes of a big body are the highest
+  -- value entries
+  let False = candPosOver 4000 body
     | True => pure (PiIntro body)
   _ <- writeIORef workBudget 600
   let mder = do da <- reTy sig ctx a emptySkel
@@ -3777,7 +3777,7 @@ export
 %noinline
 birthPiE : Sig -> Ctx -> Ty -> Ty -> Elem -> Elem -> Elem
 birthPiE sig ctx a b f e = unsafePerformIO $ do
-  let False = candPosOver 150 (PiApp f e)
+  let False = candPosOver 4000 (PiApp f e)
     | True => pure (PiApp f e)
   -- the spine fires per node: a small budget makes a store-served
   -- birth cheap and a reconstruction-shaped one bail immediately

--- a/src/idris/Nova/Kernel/Reconstruct.idr
+++ b/src/idris/Nova/Kernel/Reconstruct.idr
@@ -374,6 +374,31 @@ concludesEq sig ctx d l r ty =
     Right (JElEq l' r' ty', _) => l' == l && r' == r && ty' == ty
     _ => False
 
+%noinline
+storedTyEq : IORef (SortedMap Integer (List (Integer, Deriv)))
+storedTyEq = mkTable 11
+
+tyEqKey : Ctx -> Ty -> Ty -> (Integer, Integer)
+tyEqKey ctx a b =
+  ( hashT 33 (hashT 33 (hashCtx 33 ctx) a) b
+  , hashT 131 (hashT 131 (hashCtx 131 ctx) a) b )
+
+concludesTyEq : Sig -> Ctx -> Deriv -> Ty -> Ty -> Bool
+concludesTyEq sig ctx d a b =
+  case runKM (conclude sig ctx d) fuelR of
+    Right (JTyEq a' b', _) => a' == a && b' == b
+    _ => False
+
+lookupTyEqDeriv : Sig -> Ctx -> Ty -> Ty -> Maybe Deriv
+lookupTyEqDeriv sig ctx a b = unsafePerformIO $ do
+  m <- readIORef storedTyEq
+  let (h1, h2) = tyEqKey ctx a b
+  case lookup h2 (fromMaybe [] (lookup h1 m)) of
+    Just d => pure (if concludesTyEq sig ctx d a b
+                      then (if reconDebug then trace "eq: stored ty-deriv used" (Just d) else Just d)
+                      else Nothing)
+    Nothing => pure Nothing
+
 lookupEqDeriv : Sig -> Ctx -> Elem -> Elem -> Ty -> Maybe Deriv
 lookupEqDeriv sig ctx l r ty = unsafePerformIO $ do
   m <- readIORef storedEq
@@ -508,6 +533,9 @@ reEqTyEnds : Sig -> Ctx -> ECert -> Ty -> Ty ->
 
 reEqTyEndsGo : Sig -> Ctx -> ECert -> Ty -> Ty ->
                (Maybe Deriv, Maybe Deriv) -> Maybe Deriv
+
+reEqTyEndsGoB : Sig -> Ctx -> ECert -> Ty -> Ty ->
+                (Maybe Deriv, Maybe Deriv) -> Maybe Deriv
 
 ||| The pre-bridge variant that REPORTS WHERE IT REACHED: when the
 ||| far side is untouched by steps, the chain closes at its own
@@ -3163,7 +3191,10 @@ reEqTyEnds sig ctx cert a b ends =
         [] => Nothing
         _ => reEqTyEndsGo sig ctx ({ pos := [] } cert) a b ends)
 
-reEqTyEndsGo sig ctx (MkECertF tyEx steps0 final posSteps) a b (endA, endB) = do
+reEqTyEndsGo sig ctx cert a b ends =
+  lookupTyEqDeriv sig ctx a b <|> reEqTyEndsGoB sig ctx cert a b ends
+
+reEqTyEndsGoB sig ctx (MkECertF tyEx steps0 final posSteps) a b (endA, endB) = do
   let Nothing = tyEx
     | _ => dbg "reqty: nested tyEx" Nothing
   oneSidedR <|> (do
@@ -3445,6 +3476,28 @@ birthEqDeriv sig ctx cert l r ty = unsafePerformIO $ do
       let (h1, h2) = eqKey ctx l r ty
       modifyIORef storedEq (\m => insert h1 ((h2, d) :: fromMaybe [] (lookup h1 m)) m)
       pure (if reconDebug then trace "eq: born \{show h1}" cert else cert)
+    Nothing => pure cert
+
+||| The type-equation twin of birthEqDeriv.
+export
+%noinline
+birthTyEqDeriv : Sig -> Ctx -> ECert -> Ty -> Ty -> ECert
+birthTyEqDeriv sig ctx cert a b = unsafePerformIO $ do
+  _ <- writeIORef workBudget 100000
+  let mder = do d <- the (Maybe Deriv) $ case cert of
+                       MkECertF Nothing [] FBeta _ => do
+                         da <- reTy sig ctx a emptySkel
+                         db <- reTy sig ctx b emptySkel
+                         pure (DNfEqTy da db)
+                       _ => reEqTy sig ctx cert a b
+                let True = concludesTyEq sig ctx d a b
+                  | False => Nothing
+                pure d
+  case mder of
+    Just d => do
+      let (h1, h2) = tyEqKey ctx a b
+      modifyIORef storedTyEq (\m => insert h1 ((h2, d) :: fromMaybe [] (lookup h1 m)) m)
+      pure (if reconDebug then trace "eq: ty born \{show h1}" cert else cert)
     Nothing => pure cert
 
 ||| A def item's two derivations (the type's formation and the

--- a/src/idris/Nova/Kernel/Reconstruct.idr
+++ b/src/idris/Nova/Kernel/Reconstruct.idr
@@ -484,6 +484,26 @@ concludesEl sig ctx d e ty =
     Right (JEl e' ty', _) => e' == e && ty' == ty
     _ => False
 
+-- entries that FAILED validation, with the Σ-length at the failure:
+-- Σ only grows, so re-validating before it has is pure re-work (a
+-- port-stored judgment citing an unsolved hole fails at every
+-- lookup until the mirror lands it — a measured 2x on the meter)
+%noinline
+invalidAt : IORef (SortedMap (Integer, Integer) Nat)
+invalidAt = mkRef 24 empty
+
+%noinline
+failedHere : (Integer, Integer) -> Nat -> IO Bool
+failedHere k n = do
+  m <- readIORef invalidAt
+  pure (case lookup k m of
+          Just n' => n' == n
+          Nothing => False)
+
+%noinline
+markFailed : (Integer, Integer) -> Nat -> IO ()
+markFailed k n = modifyIORef invalidAt (insert k n)
+
 lookupElDeriv : Sig -> Ctx -> Elem -> Ty -> Maybe Deriv
 lookupElDeriv sig ctx e ty = unsafePerformIO $ do
   m <- readIORef storedEl
@@ -492,12 +512,18 @@ lookupElDeriv sig ctx e ty = unsafePerformIO $ do
     Just d =>
       if isValidated (h1 + 63, h2)
         then Just <$> serveShared (h1, h2) ctx d
-        else if concludesEl sig ctx d e ty
-          then do
-            _ <- markValidated (h1 + 63, h2)
-            d' <- serveShared (h1, h2) ctx d
-            pure (if reconDebug then trace "el: stored deriv used" (Just d') else Just d')
-          else pure (if reconDebug then trace "el: stored deriv stale" Nothing else Nothing)
+        else do
+          let n = length (toList sig)
+          False <- failedHere (h1 + 63, h2) n
+            | True => pure Nothing
+          if concludesEl sig ctx d e ty
+            then do
+              _ <- markValidated (h1 + 63, h2)
+              d' <- serveShared (h1, h2) ctx d
+              pure (if reconDebug then trace "el: stored deriv used" (Just d') else Just d')
+            else do
+              markFailed (h1 + 63, h2) n
+              pure (if reconDebug then trace "el: stored deriv stale" Nothing else Nothing)
     Nothing => pure Nothing
 
 -- births store OPTIMISTICALLY: the lookup validates before every
@@ -693,12 +719,18 @@ lookupTyDeriv sig ctx t = unsafePerformIO $ do
     Just d =>
       if isValidated (h1 + 127, h2)
         then Just <$> serveShared (h1 + 5, h2) ctx d
-        else if concludesTy sig ctx d t
-          then do
-            _ <- markValidated (h1 + 127, h2)
-            d' <- serveShared (h1 + 5, h2) ctx d
-            pure (if reconDebug then trace "ty: stored formation used" (Just d') else Just d')
-          else pure Nothing
+        else do
+          let n = length (toList sig)
+          False <- failedHere (h1 + 127, h2) n
+            | True => pure Nothing
+          if concludesTy sig ctx d t
+            then do
+              _ <- markValidated (h1 + 127, h2)
+              d' <- serveShared (h1 + 5, h2) ctx d
+              pure (if reconDebug then trace "ty: stored formation used" (Just d') else Just d')
+            else do
+              markFailed (h1 + 127, h2) n
+              pure Nothing
     Nothing => pure Nothing
 
 %noinline
@@ -733,9 +765,15 @@ lookupElDerivAt sig ctx e ty dF =
         then go rest
         else do
           let (h1, h2) = elKey ctx e ty'
-          let ok = isValidated (h1 + 63, h2) || concludesEl sig ctx d e ty'
+          let n = length (toList sig)
+          preFailed <- failedHere (h1 + 63, h2) n
+          let ok = not preFailed
+                   && (isValidated (h1 + 63, h2) || concludesEl sig ctx d e ty')
           if not ok
-            then go rest
+            then do
+              when (not preFailed && not (isValidated (h1 + 63, h2)))
+                (markFailed (h1 + 63, h2) n)
+              go rest
             else do
               _ <- markValidated (h1 + 63, h2)
               dS <- serveShared (h1, h2) ctx d

--- a/src/idris/Nova/Kernel/Reconstruct.idr
+++ b/src/idris/Nova/Kernel/Reconstruct.idr
@@ -3521,6 +3521,33 @@ birthEqDeriv sig ctx cert l r ty = unsafePerformIO $ do
       pure (if reconDebug then trace "eq: born \{show h1}" cert else cert)
     Nothing => pure cert
 
+||| An ℕ-elim's typing, born where the elaborator still HOLDS the
+||| motive (core syntax drops it — that loss is what the seat's
+||| motive guessing exists to reconstruct). Premises come through
+||| the adapter, which is lookup-first, so child typings compose
+||| from the store as more routes port. Returns the constructed
+||| spelling so the caller's data flow carries the effect.
+export
+%noinline
+birthNatE : Sig -> Ctx -> Ty -> Elem -> Elem -> Elem -> Elem
+birthNatE sig ctx mot z s t = unsafePerformIO $ do
+  _ <- writeIORef workBudget 100000
+  let concl = substTy mot (Ext Id t)
+  let mder = do dmot <- reTy sig (ctx :< Ty.NatTy) mot emptySkel
+                dz <- reCheck sig ctx z (substTy mot (Ext Id NatIntro0)) emptySkel
+                ds <- reCheck sig (ctx :< Ty.NatTy :< mot) s
+                        (substTy mot (Chain (Ext Wk (NatIntro1 (CtxVar 0))) Wk)) emptySkel
+                dt <- reCheck sig ctx t Ty.NatTy emptySkel
+                let d = DElNatE dmot dz ds dt
+                let True = concludesEl sig ctx d (NatElim z s t) concl
+                  | False => Nothing
+                pure d
+  case mder of
+    Just d => do
+      _ <- storeElDeriv ctx (NatElim z s t) concl d
+      pure (if reconDebug then trace "el: natE born" (NatElim z s t) else NatElim z s t)
+    Nothing => pure (NatElim z s t)
+
 ||| The type-equation twin of birthEqDeriv.
 export
 %noinline

--- a/src/idris/Nova/Kernel/Reconstruct.idr
+++ b/src/idris/Nova/Kernel/Reconstruct.idr
@@ -2122,6 +2122,9 @@ dTag _ = "?"
 
 lemBridgeT : Sig -> Ctx -> List Step -> Nat -> Ty -> Ty -> Maybe Deriv
 
+-- refl where the spellings already agree, the bridge otherwise
+lemBridgeTR : Sig -> Ctx -> List Step -> Nat -> Ty -> Ty -> Maybe Deriv
+
 -- a ℕ-constructor spelling's typing, written down directly (a
 -- reflected equation's side has no structural projection, but its
 -- SPELLING is in the walker's hand)
@@ -2194,8 +2197,9 @@ fitEntry sig mctx dE dA = fromMaybe plainCoe $ do
         then Just plainCoe
         else do
           let pool = unsafePerformIO (readIORef licPoolRef)
+          _ <- resetBudget 50000
           dBr <- dbg "wit: fitE bridge dead \{show tEN} VS \{show tAN}"
-                   (lemBridgeT sig ctx pool 6 tEN tAN)
+                   (lemBridgeT sig ctx pool 16 tEN tAN)
           -- tE ≐ tEN ≐ tAN ≐ tA, each leg its own rule
           pure (DElTyCoe (DTySym (DNfExpandTy dA))
                  (DElTyCoe dBr
@@ -2222,8 +2226,9 @@ fitNode sig mctx old new = fromMaybe plainCoe $ do
         then Just plainCoe
         else do
           let pool = unsafePerformIO (readIORef licPoolRef)
+          _ <- resetBudget 50000
           dBr <- dbg "wit: fitN bridge dead \{show tNN} VS \{show tON}"
-                   (lemBridgeT sig ctx pool 6 tNN tON)
+                   (lemBridgeT sig ctx pool 16 tNN tON)
           pure (DElTyCoe (DTySym (DNfExpandTy (DPresupElTy old)))
                  (DElTyCoe dBr
                    (DElTyCoe (DNfExpandTy (DPresupElTy new)) new)))
@@ -2558,10 +2563,12 @@ lemBridgeT sig ctx pool (S fuel) (El x) (El y) =
   if x == y
     then DTyRefl <$> reTy sig ctx (El x) emptySkel
     else do
-      -- the pool is tiny and fully instantiated: no matches means
-      -- no bridge, decided before anything walks or checks
+      -- the pool is tiny and fully instantiated: nothing to try
+      -- means no bridge, decided before anything walks or checks
+      -- (closeAt can still PROPOSE instances from the pool's lemmas
+      -- and the signature's laws, so only a bare call bails)
       let is = recInsts
-      let False = null is
+      let False = null is && null pool
         | True => Nothing
       _ <- if reconDebug
              then trace "wit: LB \{show (length is)} insts FOR \{show x} VS \{show y}: \{show (map (\(u, v, _) => (u, v)) is)}" (Just ())
@@ -2799,15 +2806,74 @@ lemBridgeT sig ctx pool (S fuel) (El x) b = goPool pool
         rec <- lemBridgeT sig ctx pool fuel (El x') b
         pure (DTyTrans dEl rec)
 
+  -- as in the El/El clause: an instance's spelling may hold a
+  -- β-redex the goal's nf'd code has contracted — offer nf'd sides,
+  -- the equation conjugated by nf-expansion
+  atNfG : (Deriv, Elem, Elem) -> List (Elem, Elem, Deriv)
+  atNfG (dEq, le, re) =
+    case (nfE sig le, nfE sig re) of
+      (Just leN, Just reN) =>
+        if leN == le && reN == re then []
+          else [(leN, reN,
+                 DElTrans (DElSym (DNfExpand (DPresupElL dEq)))
+                   (DElTrans dEq (DNfExpand (DPresupElR dEq))))]
+      _ => []
+
+  -- closed signature laws instantiated by matching against the
+  -- SUBTERMS the rewrite could land on (small ones only)
+  propG : List (Elem, Elem, Deriv)
+  propG =
+    concatMap (\q =>
+      case subAtE q x of
+        Just (Left sub) =>
+          if candPosOver 30 sub then []
+            else sigLawInsts sig ctx (sub, sub)
+        _ => [])
+      ([] :: take 40 (snd (candPosB 160 [] x)))
+
+  insts : List (Elem, Elem, Deriv)
+  insts =
+    concatMap (\st =>
+      (case reLicensed sig ctx st 0 of
+         Just (dEq, le, re, _) => [(le, re, dEq)] ++ atNfG (dEq, le, re)
+         Nothing => [])
+      ++ (case reLicensedRaw sig ctx st 0 of
+            Just (dEq, le, re, _) => [(le, re, dEq)] ++ atNfG (dEq, le, re)
+            Nothing => [])) pool
+    ++ propG
+
   goPool : List Step -> Maybe Deriv
-  goPool [] = Nothing
-  goPool (st :: rest) =
-    (do (dEq, le, re, _) <- reLicensed sig ctx st 0
-        tryInst dEq le re <|> tryInst (DElSym dEq) re le)
-    <|> (do (dEq, le, re, _) <- reLicensedRaw sig ctx st 0
-            tryInst dEq le re <|> tryInst (DElSym dEq) re le)
-    <|> goPool rest
+  goPool _ = goIs insts
+   where
+    goIs : List (Elem, Elem, Deriv) -> Maybe Deriv
+    goIs [] = dbg "wit: LBf dead \{show x} VS \{show b}" Nothing
+    goIs ((le, re, dEq) :: rest) =
+      tryInst dEq le re <|> tryInst (DElSym dEq) re le <|> goIs rest
+-- a Π/Σ pair differing at an inner component: component-wise
+-- congruence, each leg refl where it already agrees (a function
+-- prefix's type shifts only at the domains the rewrite reaches)
+lemBridgeT sig ctx pool (S fuel) (Ty.PiTy a0 b0) (Ty.PiTy a1 b1) =
+  -- structural descent, not search: the types shrink, so the fuel
+  -- (which bounds the REWRITE chains) carries through undiminished
+  (if reconDebug then trace "wit: LBpi enter \{show fuel}" (Just ()) else Just ()) >>= \_ =>
+  [| DTyPiCong (dbg "wit: LBpi dom dead \{show a0} VS \{show a1}"
+                 (lemBridgeTR sig ctx pool (S fuel) a0 a1))
+               (dbg "wit: LBpi cod dead"
+                 (lemBridgeTR sig (ctx :< a1) pool (S fuel) b0 b1)) |]
+lemBridgeT sig ctx pool (S fuel) (Ty.SigmaTy a0 b0) (Ty.SigmaTy a1 b1) =
+  [| DTySigmaCong (lemBridgeTR sig ctx pool (S fuel) a0 a1)
+                  (lemBridgeTR sig (ctx :< a1) pool (S fuel) b0 b1) |]
+-- an exposed former against an El code: the El-vs-former clause,
+-- mirrored (the unfolding blocked behind an index law can sit on
+-- either side)
+lemBridgeT sig ctx pool (S fuel) a b@(El _) =
+  DTySym <$> dbg "wit: LBflip dead" (lemBridgeT sig ctx pool (S fuel) b a)
 lemBridgeT _ _ _ _ _ _ = Nothing
+
+lemBridgeTR sig ctx pool fuel a b =
+  if a == b
+    then DTyRefl <$> (lookupTyDeriv sig ctx a <|> reTy sig ctx a emptySkel)
+    else lemBridgeT sig ctx pool fuel a b
 
 eqAtNf : Sig -> Ctx -> Deriv -> Ty -> Ty -> Maybe Deriv
 eqAtNf sig ctx dEq cur tgt =

--- a/src/idris/Nova/Kernel/Reconstruct.idr
+++ b/src/idris/Nova/Kernel/Reconstruct.idr
@@ -2993,7 +2993,15 @@ rePlaceE sig ctx step d [] exp cur mty wit =
                         (meetLe 24 (DElRefl (DPresupElL dEq0)) le)
                pure (DElTrans (DElSym dch) dEq0)
     d' <- if t == exp then Just dEq
-          else do
+          else (do
+            -- component-wise bridge on the RAW spellings first: nf
+            -- of the whole instance is exactly the blowup this leaf
+            -- keeps dying on, while the components stay small
+            let pool = readLicPool ()
+            dBr <- lemBridgeTF sig ctx pool 16
+                     (Just (DPresupElTy (DPresupElL dEq)), Nothing) t exp
+            pure (DElEqTyCoe dBr dEq))
+          <|> do
             tN <- dbg "leaf: fit nfT t dead \{show t}" (nfT sig t)
             eN <- dbg "leaf: fit nfT exp dead \{show exp}" (nfT sig exp)
             if tN == eN

--- a/src/idris/Nova/Kernel/Reconstruct.idr
+++ b/src/idris/Nova/Kernel/Reconstruct.idr
@@ -320,25 +320,69 @@ withMemoH ref h1 h2 act = unsafePerformIO $ do
       modifyIORef ref (insert h1 ((h2, v) :: bucket))
       pure v
 
+-- one constructor per table, applied to a distinct tag: identical
+-- right-hand sides (unsafePerformIO (newIORef empty)) are merged by
+-- the backend into ONE shared reference — the tables must differ
+-- syntactically to exist separately
+%noinline
+mkTable : Ord k => Integer -> IORef (SortedMap k v)
+mkTable _ = unsafePerformIO (newIORef empty)
+
 %noinline
 memoNfE : IORef (SortedMap Integer (List (Integer, Maybe Elem)))
-memoNfE = unsafePerformIO (newIORef empty)
+memoNfE = mkTable 1
 
 %noinline
 memoNfT : IORef (SortedMap Integer (List (Integer, Maybe Ty)))
-memoNfT = unsafePerformIO (newIORef empty)
+memoNfT = mkTable 2
 
 %noinline
 memoChk : IORef (SortedMap Integer (List (Integer, Maybe Deriv)))
-memoChk = unsafePerformIO (newIORef empty)
+memoChk = mkTable 3
 
 %noinline
 memoInf : IORef (SortedMap Integer (List (Integer, Maybe (Deriv, Ty))))
-memoInf = unsafePerformIO (newIORef empty)
+memoInf = mkTable 4
 
 %noinline
 memoTy : IORef (SortedMap Integer (List (Integer, Maybe Deriv)))
-memoTy = unsafePerformIO (newIORef empty)
+memoTy = mkTable 5
+
+-- ===== derivations born at certificate birth =====
+--
+-- The judgment-carrying pilot (docs/NovaPipeline.txt, "Phase 3
+-- end-state, revised"): when the discharge engine certifies a ⋆
+-- equation, the derivation is assembled THERE — where the engine's
+-- knowledge is in hand — validated by conclude, and stored; the
+-- seat's star routes prefer a stored derivation and fall back to
+-- reconstruction. Every consumer revalidates against ITS signature
+-- before use, so a derivation gone stale (a hole solved since
+-- birth) costs a fallback, never a rejection.
+
+%noinline
+storedEq : IORef (SortedMap Integer (List (Integer, Deriv)))
+storedEq = mkTable 10
+
+eqKey : Ctx -> Elem -> Elem -> Ty -> (Integer, Integer)
+eqKey ctx l r ty =
+  ( hashT 33 (hashE 33 (hashE 33 (hashCtx 33 ctx) l) r) ty
+  , hashT 131 (hashE 131 (hashE 131 (hashCtx 131 ctx) l) r) ty )
+
+concludesEq : Sig -> Ctx -> Deriv -> Elem -> Elem -> Ty -> Bool
+concludesEq sig ctx d l r ty =
+  case runKM (conclude sig ctx d) fuelR of
+    Right (JElEq l' r' ty', _) => l' == l && r' == r && ty' == ty
+    _ => False
+
+lookupEqDeriv : Sig -> Ctx -> Elem -> Elem -> Ty -> Maybe Deriv
+lookupEqDeriv sig ctx l r ty = unsafePerformIO $ do
+  m <- readIORef storedEq
+  let (h1, h2) = eqKey ctx l r ty
+  case lookup h2 (fromMaybe [] (lookup h1 m)) of
+    Just d => pure (if concludesEq sig ctx d l r ty
+                      then (if reconDebug then trace "eq: stored deriv used" (Just d) else Just d)
+                      else (if reconDebug then trace "eq: stored deriv stale" Nothing else Nothing))
+    Nothing => pure Nothing
 
 -- the per-item WORK BUDGET: one countdown over every reconstruction
 -- entry point. An attempt subtree that would run for minutes burns
@@ -366,19 +410,19 @@ resetBudget n = unsafePerformIO $ do
 
 %noinline
 memoResc : IORef (SortedMap String (Maybe Deriv))
-memoResc = unsafePerformIO (newIORef empty)
+memoResc = mkTable 6
 
 %noinline
 memoBr : IORef (SortedMap String (Maybe Deriv))
-memoBr = unsafePerformIO (newIORef empty)
+memoBr = mkTable 7
 
 %noinline
 memoLL : IORef (SortedMap String (Maybe (Deriv, Ty)))
-memoLL = unsafePerformIO (newIORef empty)
+memoLL = mkTable 8
 
 %noinline
 memoLB : IORef (SortedMap String (Maybe Deriv))
-memoLB = unsafePerformIO (newIORef empty)
+memoLB = mkTable 9
 
 withMemo : IORef (SortedMap String (Maybe a)) -> String -> Lazy (Maybe a) -> Maybe a
 withMemo ref k act = unsafePerformIO $ do
@@ -444,6 +488,9 @@ reEqEnds : Sig -> Ctx -> ECert -> Elem -> Elem -> Ty ->
 
 reEqEndsGo : Sig -> Ctx -> ECert -> Elem -> Elem -> Ty ->
              Maybe (Deriv, Deriv) -> Maybe Deriv
+
+reEqEndsGoB : Sig -> Ctx -> ECert -> Elem -> Elem -> Ty ->
+              Maybe (Deriv, Deriv) -> Maybe Deriv
 
 ||| … the ⋆-goal entry: on legacy failure, the certificate is
 ||| re-expressed positionally against the goal's own spellings (the
@@ -2932,7 +2979,10 @@ reEqStar sig ctx cert l r ty ends =
             dbg "resc: scripted \{show (length (pl ++ pr))} but the replay declined for \{show l}"
               (reEqEndsGo sig ctx ({ pos := pl ++ pr } cert) l r ty ends))
 
-reEqEndsGo sig ctx (MkECertF tyEx steps0 final posSteps) l r ty ends =
+reEqEndsGo sig ctx cert l r ty ends =
+  lookupEqDeriv sig ctx l r ty <|> reEqEndsGoB sig ctx cert l r ty ends
+
+reEqEndsGoB sig ctx (MkECertF tyEx steps0 final posSteps) l r ty ends =
   (if reconDebug then trace "reqe: \{show l} EQ \{show r} nsteps \{show (length steps)} tyEx \{show (maybe False (const True) tyEx)}" (Just ()) else Just ()) >>= \_ => do
   -- a POSITIONAL replay is re-expressed against the equation's own
   -- spellings at its RAW type: the recorded type-expansion belongs
@@ -3365,6 +3415,37 @@ emitBody sig ctx body ty bodySk dT =
                  (reCheck sig ctx body tyN bodySk
                   <|> reCheckF sig ctx body tyN bodySk dTN)
           pure (DElTyCoe (DTySym (DNfExpandTy dT)) d))
+
+||| At certificate birth: a ⋆ equation whose certificate closes by
+||| pure computation (no steps, no type expansion) is one nf-oracle
+||| node over its endpoint typings — assemble, validate by conclude,
+||| store. Anything else stays with the seat's translator for now;
+||| the refiner grows here. Returns its certificate so the caller's
+||| data flow carries the effect (the caller is pure).
+export
+%noinline
+birthEqDeriv : Sig -> Ctx -> ECert -> Elem -> Elem -> Ty -> ECert
+birthEqDeriv sig ctx cert l r ty = unsafePerformIO $ do
+  _ <- writeIORef workBudget 100000
+  let mder = do d <- the (Maybe Deriv) $ case cert of
+                       -- pure computation: one nf-oracle node over
+                       -- the endpoint typings
+                       MkECertF Nothing [] FBeta _ => do
+                         dl <- reCheck sig ctx l ty emptySkel
+                         dr <- reCheck sig ctx r ty emptySkel
+                         pure (DNfEq dl dr)
+                       -- anything stepped: the translator, run ONCE
+                       -- here instead of per seat attempt
+                       _ => reEqStar sig ctx cert l r ty Nothing
+                let True = concludesEq sig ctx d l r ty
+                  | False => Nothing
+                pure d
+  case mder of
+    Just d => do
+      let (h1, h2) = eqKey ctx l r ty
+      modifyIORef storedEq (\m => insert h1 ((h2, d) :: fromMaybe [] (lookup h1 m)) m)
+      pure (if reconDebug then trace "eq: born \{show h1}" cert else cert)
+    Nothing => pure cert
 
 ||| A def item's two derivations (the type's formation and the
 ||| body's typing). Nothing = emission does not cover the item (the

--- a/src/idris/Nova/Kernel/Reconstruct.idr
+++ b/src/idris/Nova/Kernel/Reconstruct.idr
@@ -484,10 +484,25 @@ lookupElDeriv sig ctx e ty = unsafePerformIO $ do
 -- use, so a wrong entry costs a fallback there — validating at birth
 -- too replays each nested premise tree per enclosing birth,
 -- quadratically
+-- the by-term secondary index: hash(Γ, t) → the (type, derivation)
+-- entries for t — the flexible lookup scans these for an nf-equal
+-- type when the exact spelling misses
+%noinline
+storedElByTm : IORef (SortedMap Integer (List (Integer, List (Ty, Deriv))))
+storedElByTm = mkTable 17
+
+tmKey : Ctx -> Elem -> (Integer, Integer)
+tmKey ctx e = (hashE 33 (hashCtx 33 ctx) e, hashE 131 (hashCtx 131 ctx) e)
+
 storeElDeriv : Ctx -> Elem -> Ty -> Deriv -> IO ()
 storeElDeriv ctx e ty d = do
   let (h1, h2) = elKey ctx e ty
   modifyIORef storedEl (\m => insert h1 ((h2, d) :: fromMaybe [] (lookup h1 m)) m)
+  let (t1, t2) = tmKey ctx e
+  modifyIORef storedElByTm (\m =>
+    let bucket = fromMaybe [] (lookup t1 m)
+        entries = fromMaybe [] (lookup t2 bucket)
+    in insert t1 ((t2, (ty, d) :: entries) :: filter (\(k, _) => k /= t2) bucket) m)
 
 tyEqKey : Ctx -> Ty -> Ty -> (Integer, Integer)
 tyEqKey ctx a b =
@@ -635,6 +650,41 @@ nfT sig t = do
     (case runKM (kTy sig t) fuelR of
        Right (x, _) => Just x
        Left _ => Nothing)
+
+||| The FLEXIBLE lookup: exact spelling first; else any stored entry
+||| for the same term whose type is nf-equal to the asked one, served
+||| through a coercion — the stored side's formation comes free by
+||| presupposition, the ASKED side's must come from the caller (the
+||| F-route threads exactly that).
+lookupElDerivAt : Sig -> Ctx -> Elem -> Ty -> Deriv -> Maybe Deriv
+lookupElDerivAt sig ctx e ty dF =
+  lookupElDeriv sig ctx e ty <|> flex
+ where
+  flex : Maybe Deriv
+  flex = unsafePerformIO $ do
+    m <- readIORef storedElByTm
+    let (t1, t2) = tmKey ctx e
+    go (fromMaybe [] (lookup t2 (fromMaybe [] (lookup t1 m))))
+   where
+    go : List (Ty, Deriv) -> IO (Maybe Deriv)
+    go [] = pure Nothing
+    go ((ty', d) :: rest) = do
+      let Just tyN = nfT sig ty
+        | Nothing => pure Nothing
+      let Just tyN' = nfT sig ty'
+        | Nothing => go rest
+      if tyN' /= tyN
+        then go rest
+        else do
+          let (h1, h2) = elKey ctx e ty'
+          let ok = isValidated (h1 + 63, h2) || concludesEl sig ctx d e ty'
+          if not ok
+            then go rest
+            else do
+              _ <- markValidated (h1 + 63, h2)
+              dS <- serveShared (h1, h2) ctx d
+              let d' = DElTyCoe (DNfEqTy (DPresupElTy dS) dF) dS
+              pure (if reconDebug then trace "el: flex deriv used" (Just d') else Just d')
 
 wkN : Nat -> Elem -> Elem
 wkN Z e = e
@@ -1219,7 +1269,8 @@ mutual
           _ => Nothing)
     <|> reCheck sig ctx Star ty sk
   reCheckF sig ctx e ty sk dF =
-    reCheck sig ctx e ty sk
+    lookupElDerivAt sig ctx e ty dF
+    <|> reCheck sig ctx e ty sk
     <|> (case payload pSw sk of
           Just cert => do
             (d, ity) <- reInfer sig ctx e (dropP isSw sk)

--- a/src/idris/Nova/Kernel/Reconstruct.idr
+++ b/src/idris/Nova/Kernel/Reconstruct.idr
@@ -385,6 +385,23 @@ storedTyEq = mkTable 11
 storedEl : IORef (SortedMap Integer (List (Integer, Deriv)))
 storedEl = mkTable 12
 
+-- entries whose validation already succeeded: Σ only grows and a
+-- derivation valid in Σ stays valid in every extension (signature
+-- weakening), so one verdict per entry suffices — without this,
+-- every hit replays its whole premise tree
+%noinline
+validated : IORef (SortedMap Integer (List Integer))
+validated = mkTable 13
+
+isValidated : (Integer, Integer) -> Bool
+isValidated (h1, h2) = unsafePerformIO $ do
+  m <- readIORef validated
+  pure (elem h2 (fromMaybe [] (lookup h1 m)))
+
+markValidated : (Integer, Integer) -> IO ()
+markValidated (h1, h2) =
+  modifyIORef validated (\m => insert h1 (h2 :: fromMaybe [] (lookup h1 m)) m)
+
 elKey : Ctx -> Elem -> Ty -> (Integer, Integer)
 elKey ctx e ty =
   ( hashT 33 (hashE 33 (hashCtx 33 ctx) e) ty
@@ -401,11 +418,20 @@ lookupElDeriv sig ctx e ty = unsafePerformIO $ do
   m <- readIORef storedEl
   let (h1, h2) = elKey ctx e ty
   case lookup h2 (fromMaybe [] (lookup h1 m)) of
-    Just d => pure (if concludesEl sig ctx d e ty
-                      then (if reconDebug then trace "el: stored deriv used" (Just d) else Just d)
-                      else (if reconDebug then trace "el: stored deriv stale" Nothing else Nothing))
+    Just d =>
+      if isValidated (h1 + 63, h2)
+        then pure (Just d)
+        else if concludesEl sig ctx d e ty
+          then do
+            _ <- markValidated (h1 + 63, h2)
+            pure (if reconDebug then trace "el: stored deriv used" (Just d) else Just d)
+          else pure (if reconDebug then trace "el: stored deriv stale" Nothing else Nothing)
     Nothing => pure Nothing
 
+-- births store OPTIMISTICALLY: the lookup validates before every
+-- use, so a wrong entry costs a fallback there — validating at birth
+-- too replays each nested premise tree per enclosing birth,
+-- quadratically
 storeElDeriv : Ctx -> Elem -> Ty -> Deriv -> IO ()
 storeElDeriv ctx e ty d = do
   let (h1, h2) = elKey ctx e ty
@@ -427,9 +453,14 @@ lookupTyEqDeriv sig ctx a b = unsafePerformIO $ do
   m <- readIORef storedTyEq
   let (h1, h2) = tyEqKey ctx a b
   case lookup h2 (fromMaybe [] (lookup h1 m)) of
-    Just d => pure (if concludesTyEq sig ctx d a b
-                      then (if reconDebug then trace "eq: stored ty-deriv used" (Just d) else Just d)
-                      else Nothing)
+    Just d =>
+      if isValidated (h1 + 21, h2)
+        then pure (Just d)
+        else if concludesTyEq sig ctx d a b
+          then do
+            _ <- markValidated (h1 + 21, h2)
+            pure (if reconDebug then trace "eq: stored ty-deriv used" (Just d) else Just d)
+          else pure Nothing
     Nothing => pure Nothing
 
 lookupEqDeriv : Sig -> Ctx -> Elem -> Elem -> Ty -> Maybe Deriv
@@ -437,9 +468,14 @@ lookupEqDeriv sig ctx l r ty = unsafePerformIO $ do
   m <- readIORef storedEq
   let (h1, h2) = eqKey ctx l r ty
   case lookup h2 (fromMaybe [] (lookup h1 m)) of
-    Just d => pure (if concludesEq sig ctx d l r ty
-                      then (if reconDebug then trace "eq: stored deriv used" (Just d) else Just d)
-                      else (if reconDebug then trace "eq: stored deriv stale" Nothing else Nothing))
+    Just d =>
+      if isValidated (h1 + 7, h2)
+        then pure (Just d)
+        else if concludesEq sig ctx d l r ty
+          then do
+            _ <- markValidated (h1 + 7, h2)
+            pure (if reconDebug then trace "eq: stored deriv used" (Just d) else Just d)
+          else pure (if reconDebug then trace "eq: stored deriv stale" Nothing else Nothing)
     Nothing => pure Nothing
 
 -- the per-item WORK BUDGET: one countdown over every reconstruction
@@ -3556,10 +3592,7 @@ birthNatE sig ctx mot z s t = unsafePerformIO $ do
                 ds <- reCheck sig (ctx :< Ty.NatTy :< mot) s
                         (substTy mot (Chain (Ext Wk (NatIntro1 (CtxVar 0))) Wk)) emptySkel
                 dt <- reCheck sig ctx t Ty.NatTy emptySkel
-                let d = DElNatE dmot dz ds dt
-                let True = concludesEl sig ctx d (NatElim z s t) concl
-                  | False => Nothing
-                pure d
+                pure (DElNatE dmot dz ds dt)
   case mder of
     Just d => do
       _ <- storeElDeriv ctx (NatElim z s t) concl d
@@ -3577,10 +3610,7 @@ birthSumE sig ctx a b mot l r t = unsafePerformIO $ do
                 dmot <- reTy sig (ctx :< Ty.SumTy a b) mot emptySkel
                 dl <- reCheck sig (ctx :< a) l (substTy mot (Ext Wk (Inj1 (CtxVar 0)))) emptySkel
                 dr <- reCheck sig (ctx :< b) r (substTy mot (Ext Wk (Inj2 (CtxVar 0)))) emptySkel
-                let d = DElSumE dt dmot dl dr
-                let True = concludesEl sig ctx d (SumElim l r t) concl
-                  | False => Nothing
-                pure d
+                pure (DElSumE dt dmot dl dr)
   case mder of
     Just d => do
       _ <- storeElDeriv ctx (SumElim l r t) concl d
@@ -3606,10 +3636,7 @@ birthQuotE sig ctx a rel mot f q wd = unsafePerformIO $ do
                 df <- reCheck sig (ctx :< a) f (substTy mot (Ext Wk (Class (CtxVar 0)))) emptySkel
                 dresp <- lookupEqDeriv sig wdCtx wdL wdR wdTy
                          <|> reEqStar sig wdCtx wd wdL wdR wdTy Nothing
-                let d = DElQuotE dq dmot df dresp
-                let True = concludesEl sig ctx d (QuotElim f q) concl
-                  | False => Nothing
-                pure d
+                pure (DElQuotE dq dmot df dresp)
   case mder of
     Just d => do
       _ <- storeElDeriv ctx (QuotElim f q) concl d

--- a/src/idris/Nova/Kernel/Reconstruct.idr
+++ b/src/idris/Nova/Kernel/Reconstruct.idr
@@ -2120,6 +2120,8 @@ dTag (DElReflect _) = "reflect"
 dTag (DCodeEqCong _ _ _) = "codeeqcong"
 dTag _ = "?"
 
+lemBridgeT : Sig -> Ctx -> List Step -> Nat -> Ty -> Ty -> Maybe Deriv
+
 -- a ℕ-constructor spelling's typing, written down directly (a
 -- reflected equation's side has no structural projection, but its
 -- SPELLING is in the walker's hand)
@@ -2170,6 +2172,65 @@ childE 0 (SigmaElim1 t) = Just t
 childE 0 (SigmaElim2 t) = Just t
 childE _ _ = Nothing
 
+-- an entry's typing coerced to the EXACT spelling an enclosing node
+-- demands: identical spellings pass through, nf-equal ones ride
+-- nf-eq, a REAL index shift rides the recorded license pool — the
+-- one coercion the walk cannot dodge (a beta-redex whose earlier
+-- argument was rewritten instantiates later domains at the new
+-- index while the entries' witnesses speak the old)
+fitEntry : Sig -> Maybe Ctx -> Deriv -> Deriv -> Deriv
+fitEntry sig mctx dE dA = fromMaybe plainCoe $ do
+  ctx <- mctx
+  Right (JEl _ tE, _) <- Just (runKM (conclude [] sig ctx dE) fuelR)
+    | _ => dbg "wit: fitE conclude dE dead" Nothing
+  Right (JTy tA, _) <- Just (runKM (conclude [] sig ctx dA) fuelR)
+    | _ => dbg "wit: fitE conclude dA dead" Nothing
+  if tE == tA
+    then Just dE
+    else do
+      tEN <- nfT sig tE
+      tAN <- nfT sig tA
+      if tEN == tAN
+        then Just plainCoe
+        else do
+          let pool = unsafePerformIO (readIORef licPoolRef)
+          dBr <- dbg "wit: fitE bridge dead \{show tEN} VS \{show tAN}"
+                   (lemBridgeT sig ctx pool 6 tEN tAN)
+          -- tE ≐ tEN ≐ tAN ≐ tA, each leg its own rule
+          pure (DElTyCoe (DTySym (DNfExpandTy dA))
+                 (DElTyCoe dBr
+                   (DElTyCoe (DNfExpandTy (DPresupElTy dE)) dE)))
+ where
+  plainCoe : Deriv
+  plainCoe = DElTyCoe (DNfEqTy (DPresupElTy dE) dA) dE
+
+-- a stepped premise coerced back to the ORIGINAL node's concluded
+-- type: same three-way fit, the target read off the old node
+fitNode : Sig -> Maybe Ctx -> Deriv -> Deriv -> Deriv
+fitNode sig mctx old new = fromMaybe plainCoe $ do
+  ctx <- mctx
+  Right (JEl _ tN, _) <- Just (runKM (conclude [] sig ctx new) fuelR)
+    | _ => dbg "wit: fitN conclude new dead" Nothing
+  Right (JEl _ tO, _) <- Just (runKM (conclude [] sig ctx old) fuelR)
+    | _ => dbg "wit: fitN conclude old dead" Nothing
+  if tN == tO
+    then Just new
+    else do
+      tNN <- nfT sig tN
+      tON <- nfT sig tO
+      if tNN == tON
+        then Just plainCoe
+        else do
+          let pool = unsafePerformIO (readIORef licPoolRef)
+          dBr <- dbg "wit: fitN bridge dead \{show tNN} VS \{show tON}"
+                   (lemBridgeT sig ctx pool 6 tNN tON)
+          pure (DElTyCoe (DTySym (DNfExpandTy (DPresupElTy old)))
+                 (DElTyCoe dBr
+                   (DElTyCoe (DNfExpandTy (DPresupElTy new)) new)))
+ where
+  plainCoe : Deriv
+  plainCoe = DElTyCoe (DNfEqTy (DPresupElTy new) (DPresupElTy old)) new
+
 mutual
   -- normalize a witness to a structural head: type coercions are
   -- transparent (the term beneath is what the walk follows), and a
@@ -2202,7 +2263,7 @@ mutual
   dvView sig (DPresupElL (DNfEq da _)) = dvView sig da
   dvView sig (DPresupElR (DNfEq _ db)) = dvView sig db
   dvView sig (DPresupElL (DBetaAt _ d)) = dvView sig d
-  dvView sig (DPresupElR (DBetaAt q d)) = stepTypedE sig q Nothing d >>= dvView sig
+  dvView sig (DPresupElR (DBetaAt q d)) = stepTypedE sig Nothing q Nothing d >>= dvView sig
   dvView sig (DPresupElL (DElAppCong dc de dB)) =
     dvView sig (DElPiE (DPresupElL dc) (DPresupElL de) dB)
   dvView sig (DPresupElR (DElAppCong dc de dB)) =
@@ -2271,8 +2332,8 @@ mutual
 
   -- the redex's contraction, witnessed: exactly step1E's head cases,
   -- each contractum's derivation assembled from the redex's premises
-  headTyped : Sig -> Maybe Elem -> Deriv -> Maybe Deriv
-  headTyped sig me d = do
+  headTyped : Sig -> Maybe Ctx -> Maybe Elem -> Deriv -> Maybe Deriv
+  headTyped sig mctx me d = do
     v <- dbg "wit: no head view" (dvView sig d)
     case v of
       DElPiE dF dE dB => do
@@ -2280,10 +2341,9 @@ mutual
         let DElPiI dA dBody = vF
           | _ => dbg "wit: head fn not lam: \{dTag vF}" Nothing
         -- the argument's typing may spell the domain differently
-        -- than the λ's own formation (recorded vs re-inferred
-        -- spellings): sub-ext checks them EXACTLY — coerce
-        let dE' = DElTyCoe (DNfEqTy (DPresupElTy dE) dA) dE
-        pure (subWrapD (DSubExt DSubId dA dE') dBody)
+        -- than the λ's own formation, or sit a REAL index shift
+        -- away: sub-ext checks spellings EXACTLY — fit the entry
+        pure (subWrapD (DSubExt DSubId dA (fitEntry sig mctx dE dA)) dBody)
       DElSig x dSubN => do
         dBody <- dbg "wit: no sig deriv \{x}"
                    (lookupSigDeriv x <|> lazySigDeriv sig x)
@@ -2314,30 +2374,29 @@ mutual
 
   ||| One ≜ contraction at a path, on the WITNESS: the enclosing nodes
   ||| rebuild around the stepped premise.
-  stepTypedE : Sig -> List Nat -> Maybe Elem -> Deriv -> Maybe Deriv
-  stepTypedE sig [] me d = headTyped sig me d
-  stepTypedE sig (i :: p) me d = do
+  stepTypedE : Sig -> Maybe Ctx -> List Nat -> Maybe Elem -> Deriv -> Maybe Deriv
+  stepTypedE sig mctx [] me d = headTyped sig mctx me d
+  stepTypedE sig mctx (i :: p) me d = do
     v <- dbg "wit: no view at \{show (i :: p)}" (dvView sig d)
     let mc = me >>= childE i
     case (v, i) of
-      (DElPiE dF dE dB, 0) => (\x => DElPiE (reTyped dF x) dE dB) <$> stepTypedE sig p mc dF
-      (DElPiE dF dE dB, 1) => (\x => DElPiE dF (reTyped dE x) dB) <$> stepTypedE sig p mc dE
-      (DElNatE dM dZ dSt dT, 0) => (\x => DElNatE dM (reTyped dZ x) dSt dT) <$> stepTypedE sig p mc dZ
-      (DElNatE dM dZ dSt dT, 1) => (\x => DElNatE dM dZ (reTyped dSt x) dT) <$> stepTypedE sig p mc dSt
-      (DElNatE dM dZ dSt dT, 2) => (\x => DElNatE dM dZ dSt (reTyped dT x)) <$> stepTypedE sig p mc dT
-      (DElNatS d', 0) => (DElNatS . reTyped d') <$> stepTypedE sig p mc d'
-      (DElSigmaI dU dB dV, 0) => (\x => DElSigmaI (reTyped dU x) dB dV) <$> stepTypedE sig p mc dU
-      (DElSigmaI dU dB dV, 1) => (\x => DElSigmaI dU dB (reTyped dV x)) <$> stepTypedE sig p mc dV
-      (DElSigmaE1 d', 0) => (DElSigmaE1 . reTyped d') <$> stepTypedE sig p mc d'
-      (DElSigmaE2 d', 0) => (DElSigmaE2 . reTyped d') <$> stepTypedE sig p mc d'
+      (DElPiE dF dE dB, 0) => (\x => DElPiE (reTyped dF x) dE dB) <$> stepTypedE sig mctx p mc dF
+      (DElPiE dF dE dB, 1) => (\x => DElPiE dF (reTyped dE x) dB) <$> stepTypedE sig mctx p mc dE
+      (DElNatE dM dZ dSt dT, 0) => (\x => DElNatE dM (reTyped dZ x) dSt dT) <$> stepTypedE sig mctx p mc dZ
+      (DElNatE dM dZ dSt dT, 1) => (\x => DElNatE dM dZ (reTyped dSt x) dT) <$> stepTypedE sig Nothing p mc dSt
+      (DElNatE dM dZ dSt dT, 2) => (\x => DElNatE dM dZ dSt (reTyped dT x)) <$> stepTypedE sig mctx p mc dT
+      (DElNatS d', 0) => (DElNatS . reTyped d') <$> stepTypedE sig mctx p mc d'
+      (DElSigmaI dU dB dV, 0) => (\x => DElSigmaI (reTyped dU x) dB dV) <$> stepTypedE sig mctx p mc dU
+      (DElSigmaI dU dB dV, 1) => (\x => DElSigmaI dU dB (reTyped dV x)) <$> stepTypedE sig mctx p mc dV
+      (DElSigmaE1 d', 0) => (DElSigmaE1 . reTyped d') <$> stepTypedE sig mctx p mc d'
+      (DElSigmaE2 d', 0) => (DElSigmaE2 . reTyped d') <$> stepTypedE sig mctx p mc d'
       _ => dbg "wit: no case at \{show (i :: p)}: \{dTag v}" Nothing
    where
-    -- a stepped premise concludes at an nf-EQUAL but possibly
-    -- differently-spelled type (an unfold rewrites the type's spelling
-    -- too); the enclosing node demands the ORIGINAL spelling exactly —
-    -- coerce back along nf-eq of the two presupposed formations
+    -- a stepped premise concludes at a differently-spelled — or
+    -- genuinely SHIFTED — type; the enclosing node demands the
+    -- ORIGINAL spelling exactly: the three-way fit closes it
     reTyped : Deriv -> Deriv -> Deriv
-    reTyped old new = DElTyCoe (DNfEqTy (DPresupElTy new) (DPresupElTy old)) new
+    reTyped old new = fitNode sig mctx old new
 
 -- the chain's rolling STRUCTURAL witness (alongside the compact
 -- presupposition witness): set per side, transformed per exposure,
@@ -2494,7 +2553,6 @@ lemmaInsts : Sig -> Ctx -> Step -> Nat -> List Elem -> (Elem, Elem) -> List (Der
 ||| recording may speak another context's variables.
 sigLawInsts : Sig -> Ctx -> (Elem, Elem) -> List (Elem, Elem, Deriv)
 
-lemBridgeT : Sig -> Ctx -> List Step -> Nat -> Ty -> Ty -> Maybe Deriv
 lemBridgeT _ _ _ Z _ _ = Nothing
 lemBridgeT sig ctx pool (S fuel) (El x) (El y) =
   if x == y
@@ -3868,7 +3926,7 @@ stepChainE sig ctx positional allSteps mTyEx ty (chain, dCur, cur) step =
       -- subject reduction run forward on the derivation (a failure
       -- just drops the witness — placements fall back to
       -- reconstruction, never the chain)
-      let w' = readChainWit () >>= stepTypedE sig step.path (Just cur)
+      let w' = readChainWit () >>= stepTypedE sig (Just ctx) step.path (Just cur)
       _ <- setChainWit (if reconDebug then trace "wit: step \{show step.path} -> \{show (isJust w')}" w' else w')
       pure (DElTrans chain link, DPresupElR link, cur')
     _ => do

--- a/src/idris/Nova/Kernel/Reconstruct.idr
+++ b/src/idris/Nova/Kernel/Reconstruct.idr
@@ -151,6 +151,12 @@ betaOnly _ = False
 fuelR : Nat
 fuelR = 1000000
 
+-- validation fuel: the walk's DEFENSIVE concludes (witness checks,
+-- premise fits) die fast rather than replay a megastep — a fuel
+-- death there is a soft verdict, never a rejection
+fuelV : Nat
+fuelV = 100000
+
 -- ===== MEMOIZED EMISSION (docs/NovaPipeline.txt, phase 3) =====
 -- The emission pass is a tree of alternatives, and every alternative
 -- re-runs everything beneath it — identical sub-problems are solved
@@ -2122,8 +2128,15 @@ dTag _ = "?"
 
 lemBridgeT : Sig -> Ctx -> List Step -> Nat -> Ty -> Ty -> Maybe Deriv
 
+-- the same bridge carrying the endpoints' FORMATION derivations
+-- where the caller has them: a refl leg or a Π/Σ component under
+-- binders must not re-derive a normalized eliminator code's
+-- formation from its spelling (the motive-guessing wall) — it
+-- inverts the formation in hand instead
+lemBridgeTF : Sig -> Ctx -> List Step -> Nat -> (Maybe Deriv, Maybe Deriv) -> Ty -> Ty -> Maybe Deriv
+
 -- refl where the spellings already agree, the bridge otherwise
-lemBridgeTR : Sig -> Ctx -> List Step -> Nat -> Ty -> Ty -> Maybe Deriv
+lemBridgeTR : Sig -> Ctx -> List Step -> Nat -> (Maybe Deriv, Maybe Deriv) -> Ty -> Ty -> Maybe Deriv
 
 -- a ℕ-constructor spelling's typing, written down directly (a
 -- reflected equation's side has no structural projection, but its
@@ -2184,9 +2197,9 @@ childE _ _ = Nothing
 fitEntry : Sig -> Maybe Ctx -> Deriv -> Deriv -> Deriv
 fitEntry sig mctx dE dA = fromMaybe plainCoe $ do
   ctx <- mctx
-  Right (JEl _ tE, _) <- Just (runKM (conclude [] sig ctx dE) fuelR)
+  Right (JEl _ tE, _) <- Just (runKM (conclude [] sig ctx dE) fuelV)
     | _ => dbg "wit: fitE conclude dE dead" Nothing
-  Right (JTy tA, _) <- Just (runKM (conclude [] sig ctx dA) fuelR)
+  Right (JTy tA, _) <- Just (runKM (conclude [] sig ctx dA) fuelV)
     | _ => dbg "wit: fitE conclude dA dead" Nothing
   if tE == tA
     then Just dE
@@ -2199,7 +2212,10 @@ fitEntry sig mctx dE dA = fromMaybe plainCoe $ do
           let pool = unsafePerformIO (readIORef licPoolRef)
           _ <- resetBudget 50000
           dBr <- dbg "wit: fitE bridge dead \{show tEN} VS \{show tAN}"
-                   (lemBridgeT sig ctx pool 16 tEN tAN)
+                   (lemBridgeTF sig ctx pool 16
+                      (Just (DPresupTyR (DNfExpandTy (DPresupElTy dE))),
+                       Just (DPresupTyR (DNfExpandTy dA)))
+                      tEN tAN)
           -- tE ≐ tEN ≐ tAN ≐ tA, each leg its own rule
           pure (DElTyCoe (DTySym (DNfExpandTy dA))
                  (DElTyCoe dBr
@@ -2213,9 +2229,9 @@ fitEntry sig mctx dE dA = fromMaybe plainCoe $ do
 fitNode : Sig -> Maybe Ctx -> Deriv -> Deriv -> Deriv
 fitNode sig mctx old new = fromMaybe plainCoe $ do
   ctx <- mctx
-  Right (JEl _ tN, _) <- Just (runKM (conclude [] sig ctx new) fuelR)
+  Right (JEl _ tN, _) <- Just (runKM (conclude [] sig ctx new) fuelV)
     | _ => dbg "wit: fitN conclude new dead" Nothing
-  Right (JEl _ tO, _) <- Just (runKM (conclude [] sig ctx old) fuelR)
+  Right (JEl _ tO, _) <- Just (runKM (conclude [] sig ctx old) fuelV)
     | _ => dbg "wit: fitN conclude old dead" Nothing
   if tN == tO
     then Just new
@@ -2228,7 +2244,10 @@ fitNode sig mctx old new = fromMaybe plainCoe $ do
           let pool = unsafePerformIO (readIORef licPoolRef)
           _ <- resetBudget 50000
           dBr <- dbg "wit: fitN bridge dead \{show tNN} VS \{show tON}"
-                   (lemBridgeT sig ctx pool 16 tNN tON)
+                   (lemBridgeTF sig ctx pool 16
+                      (Just (DPresupTyR (DNfExpandTy (DPresupElTy new))),
+                       Just (DPresupTyR (DNfExpandTy (DPresupElTy old))))
+                      tNN tON)
           pure (DElTyCoe (DTySym (DNfExpandTy (DPresupElTy old)))
                  (DElTyCoe dBr
                    (DElTyCoe (DNfExpandTy (DPresupElTy new)) new)))
@@ -2420,13 +2439,19 @@ setChainWit w = unsafePerformIO $ do
 readChainWit : () -> Maybe Deriv
 readChainWit _ = unsafePerformIO (readIORef chainWit)
 
--- an equation replay is RE-ENTRANT (a chain step licenses through
--- nested replays, each seeding its own witness and clearing it on
--- exit): the outer chain's witness is restored around every body
 %noinline
-restoreWitAfter : Maybe Deriv -> Maybe a -> Maybe a
-restoreWitAfter saved r = unsafePerformIO $ do
-  writeIORef chainWit saved
+readLicPool : () -> List Step
+readLicPool _ = unsafePerformIO (readIORef licPoolRef)
+
+-- an equation replay is RE-ENTRANT (a chain step licenses through
+-- nested replays, each seeding its own witness and license pool and
+-- clearing them on exit): the outer chain's state is restored
+-- around every body
+%noinline
+restoreWitAfter : (Maybe Deriv, List Step) -> Maybe a -> Maybe a
+restoreWitAfter (savedW, savedP) r = unsafePerformIO $ do
+  writeIORef chainWit savedW
+  writeIORef licPoolRef savedP
   pure r
 
 
@@ -2443,13 +2468,13 @@ elWitFor sig ctx e = unsafePerformIO $ do
 
 witEl : Sig -> Ctx -> Deriv -> Maybe (Elem, Ty)
 witEl sig ctx dw =
-  case runKM (conclude [] sig ctx dw) fuelR of
+  case runKM (conclude [] sig ctx dw) fuelV of
     Right (JEl e t, _) => Just (e, t)
     _ => Nothing
 
 witTy : Sig -> Ctx -> Deriv -> Maybe Ty
 witTy sig ctx dw =
-  case runKM (conclude [] sig ctx dw) fuelR of
+  case runKM (conclude [] sig ctx dw) fuelV of
     Right (JTy t, _) => Just t
     _ => Nothing
 
@@ -2477,12 +2502,19 @@ plainWit sig ctx e = unsafePerformIO $ do
 witView : Sig -> Ctx -> Elem -> Maybe Deriv -> Maybe Deriv
 witView sig ctx cur wit = do
   w <- wit
-  case runKM (conclude [] sig ctx w) fuelR of
+  case runKM (conclude [] sig ctx w) fuelV of
     Right (JEl e _, _) =>
       if e == cur then dbg "wit: view crack miss \{dTag w}" (dvView sig w)
         else dbg "wit: view speaks \{show e} not \{show cur}" Nothing
     Right _ => dbg "wit: view not an El judgment" Nothing
-    Left err => dbg "wit: view conclude: \{err}" Nothing
+    Left err =>
+      -- a fitted composite can out-fuel the DEFENSIVE erasure check
+      -- without being wrong (its coercions re-normalize per level);
+      -- the walk stays untrusted either way — the seat replays the
+      -- final artifact with the real fuel
+      if err == "kernel: out of fuel"
+        then dvView sig w
+        else dbg "wit: view conclude: \{err}" Nothing
 
 stKey : Maybe Step -> String
 stKey Nothing = "-"
@@ -2558,17 +2590,22 @@ lemmaInsts : Sig -> Ctx -> Step -> Nat -> List Elem -> (Elem, Elem) -> List (Der
 ||| recording may speak another context's variables.
 sigLawInsts : Sig -> Ctx -> (Elem, Elem) -> List (Elem, Elem, Deriv)
 
-lemBridgeT _ _ _ Z _ _ = Nothing
-lemBridgeT sig ctx pool (S fuel) (El x) (El y) =
+lemBridgeT sig ctx pool fuel a b =
+  lemBridgeTF sig ctx pool fuel (Nothing, Nothing) a b
+
+lemBridgeTF _ _ _ Z _ _ _ = Nothing
+lemBridgeTF sig ctx pool (S fuel) (mFL, _) (El x) (El y) =
   if x == y
-    then DTyRefl <$> reTy sig ctx (El x) emptySkel
+    then DTyRefl <$> (mFL <|> lookupTyDeriv sig ctx (El x)
+                          <|> reTy sig ctx (El x) emptySkel)
     else do
-      -- the pool is tiny and fully instantiated: nothing to try
-      -- means no bridge, decided before anything walks or checks
-      -- (closeAt can still PROPOSE instances from the pool's lemmas
-      -- and the signature's laws, so only a bare call bails)
+      -- bail early only when nothing can fire: no recordings, no
+      -- pool to propose from, AND a pair too large for the
+      -- signature-law matcher (small pairs still reach closeAt,
+      -- whose proposals need no pool — the under-binder case)
       let is = recInsts
       let False = null is && null pool
+                    && (candPosOver 40 x || candPosOver 40 y)
         | True => Nothing
       _ <- if reconDebug
              then trace "wit: LB \{show (length is)} insts FOR \{show x} VS \{show y}: \{show (map (\(u, v, _) => (u, v)) is)}" (Just ())
@@ -2762,7 +2799,7 @@ lemBridgeT sig ctx pool (S fuel) (El x) (El y) =
 -- one side El, the other an EXPOSED former: the unfolding is
 -- blocked behind an index law — rewrite the code by a recorded
 -- instance at an exact occurrence, then close through the oracle
-lemBridgeT sig ctx pool (S fuel) (El x) b = goPool pool
+lemBridgeTF sig ctx pool (S fuel) _ (El x) b = goPool pool
  where
   firstPosG : Elem -> Elem -> Maybe (List Nat)
   firstPosG le z = goP (snd (candPosB 160 [] z))
@@ -2852,28 +2889,36 @@ lemBridgeT sig ctx pool (S fuel) (El x) b = goPool pool
 -- a Π/Σ pair differing at an inner component: component-wise
 -- congruence, each leg refl where it already agrees (a function
 -- prefix's type shifts only at the domains the rewrite reaches)
-lemBridgeT sig ctx pool (S fuel) (Ty.PiTy a0 b0) (Ty.PiTy a1 b1) =
+lemBridgeTF sig ctx pool (S fuel) (mFL, mFR) (Ty.PiTy a0 b0) (Ty.PiTy a1 b1) =
   -- structural descent, not search: the types shrink, so the fuel
-  -- (which bounds the REWRITE chains) carries through undiminished
+  -- (which bounds the REWRITE chains) carries through undiminished;
+  -- component formations by INVERSION of the ones in hand
   (if reconDebug then trace "wit: LBpi enter \{show fuel}" (Just ()) else Just ()) >>= \_ =>
   [| DTyPiCong (dbg "wit: LBpi dom dead \{show a0} VS \{show a1}"
-                 (lemBridgeTR sig ctx pool (S fuel) a0 a1))
+                 (lemBridgeTR sig ctx pool (S fuel)
+                    (DInvPiDom <$> mFL, DInvPiDom <$> mFR) a0 a1))
                (dbg "wit: LBpi cod dead"
-                 (lemBridgeTR sig (ctx :< a1) pool (S fuel) b0 b1)) |]
-lemBridgeT sig ctx pool (S fuel) (Ty.SigmaTy a0 b0) (Ty.SigmaTy a1 b1) =
-  [| DTySigmaCong (lemBridgeTR sig ctx pool (S fuel) a0 a1)
-                  (lemBridgeTR sig (ctx :< a1) pool (S fuel) b0 b1) |]
+                 (lemBridgeTR sig (ctx :< a1) pool (S fuel)
+                    (DInvPiCod <$> mFL, DInvPiCod <$> mFR) b0 b1)) |]
+lemBridgeTF sig ctx pool (S fuel) (mFL, mFR) (Ty.SigmaTy a0 b0) (Ty.SigmaTy a1 b1) =
+  [| DTySigmaCong (lemBridgeTR sig ctx pool (S fuel)
+                     (DInvSigmaDom <$> mFL, DInvSigmaDom <$> mFR) a0 a1)
+                  (lemBridgeTR sig (ctx :< a1) pool (S fuel)
+                     (DInvSigmaCod <$> mFL, DInvSigmaCod <$> mFR) b0 b1) |]
 -- an exposed former against an El code: the El-vs-former clause,
 -- mirrored (the unfolding blocked behind an index law can sit on
 -- either side)
-lemBridgeT sig ctx pool (S fuel) a b@(El _) =
-  DTySym <$> dbg "wit: LBflip dead" (lemBridgeT sig ctx pool (S fuel) b a)
-lemBridgeT _ _ _ _ _ _ = Nothing
+lemBridgeTF sig ctx pool (S fuel) (mFL, mFR) a b@(El _) =
+  DTySym <$> dbg "wit: LBflip dead"
+    (lemBridgeTF sig ctx pool (S fuel) (mFR, mFL) b a)
+lemBridgeTF _ _ _ fuel _ a b =
+  dbg "wit: LB catchall f=\{show fuel} \{show a} VS \{show b}" Nothing
 
-lemBridgeTR sig ctx pool fuel a b =
+lemBridgeTR sig ctx pool fuel (mFL, mFR) a b =
   if a == b
-    then DTyRefl <$> (lookupTyDeriv sig ctx a <|> reTy sig ctx a emptySkel)
-    else lemBridgeT sig ctx pool fuel a b
+    then DTyRefl <$> (mFL <|> mFR <|> lookupTyDeriv sig ctx a
+                          <|> reTy sig ctx a emptySkel)
+    else lemBridgeTF sig ctx pool fuel (mFL, mFR) a b
 
 eqAtNf : Sig -> Ctx -> Deriv -> Ty -> Ty -> Maybe Deriv
 eqAtNf sig ctx dEq cur tgt =
@@ -2911,8 +2956,9 @@ eqAtLem sig ctx dEq cur tgt =
 ||| (cur ≐ cur′ at the expected type) and cur′.
 rePlaceE : Sig -> Ctx -> Step -> Nat -> List Nat -> Ty -> Elem -> Maybe Deriv -> Maybe Deriv -> Maybe (Deriv, Elem, Ty)
 rePlaceE sig ctx step d [] exp cur mty wit =
-  leafWith True (reLicensedRaw sig ctx step d)
+  leafWith True (dbg "leaf: raw license dead" (reLicensedRaw sig ctx step d))
   <|> leafWith False (dbg "leaf: license" (reLicensed sig ctx step d))
+  <|> dbg "leaf: declined cur=\{show cur} exp=\{show exp}" Nothing
  where
   -- the licensed lhs may be spelled a few ≜ steps ABOVE the position's
   -- spelling: contract it toward cur, each move a beta-at link
@@ -2941,19 +2987,19 @@ rePlaceE sig ctx step d [] exp cur mty wit =
              else do
                let True = allowMeet
                  | False => Nothing
-               let False = candPosOver 80 le
-                 | True => Nothing
+               let False = candPosOver 400 le
+                 | True => dbg "leaf: meet size gate" Nothing
                dch <- dbg "leaf: cur \{show cur} /= licensed \{show le}"
                         (meetLe 24 (DElRefl (DPresupElL dEq0)) le)
                pure (DElTrans (DElSym dch) dEq0)
     d' <- if t == exp then Just dEq
           else do
-            tN <- nfT sig t
-            eN <- nfT sig exp
+            tN <- dbg "leaf: fit nfT t dead \{show t}" (nfT sig t)
+            eN <- dbg "leaf: fit nfT exp dead \{show exp}" (nfT sig exp)
             if tN == eN
               then do
-                dt <- reTy sig ctx t emptySkel
-                de <- reTy sig ctx exp emptySkel
+                dt <- dbg "leaf: fit reTy t \{show t}" (reTy sig ctx t emptySkel)
+                de <- dbg "leaf: fit reTy exp \{show exp}" (reTy sig ctx exp emptySkel)
                 pure (DElEqTyCoe (DNfEqTy dt de) dEq)
               else do
                 -- a dependent position shifted by an earlier rewrite:
@@ -2961,8 +3007,10 @@ rePlaceE sig ctx step d [] exp cur mty wit =
                 -- license pool closes what nf cannot
                 let pool@(_ :: _) = unsafePerformIO (readIORef licPoolRef)
                   | [] => Nothing
-                dBr <- lemBridgeT sig ctx pool 3 tN eN
-                dE <- lookupTyDeriv sig ctx exp <|> reTy sig ctx exp emptySkel
+                dBr <- dbg "leaf: fit pool \{show tN} VS \{show eN}"
+                         (lemBridgeT sig ctx pool 3 tN eN)
+                dE <- dbg "leaf: fit exp form"
+                        (lookupTyDeriv sig ctx exp <|> reTy sig ctx exp emptySkel)
                 let dT = DPresupElTy (DPresupElL dEq)
                 let dTN = DPresupTyR (DNfExpandTy dT)
                 let atN = DElEqTyCoe dBr (DElEqTyCoe (DNfEqTy dT dTN) dEq)
@@ -3054,7 +3102,12 @@ rePlaceE sig ctx step d (i :: p) exp cur mty wit =
           | v => dbg "wit: pair1 not pair: \{dTag v}" Nothing
         (_, a) <- dbg "wit: pair1 fst conclude miss" (witEl sig ctx wU)
         b <- dbg "wit: pair1 family conclude miss" (witTy sig (ctx :< a) wB)
-        (dc0, v', chTy) <- rePlaceE sig ctx step d p (substTy b (Ext Id u)) v Nothing (Just wV)
+        -- the recursion runs at the WITNESS's spelling of v's type
+        -- (the license speaks that world); eqAtLem bridges the
+        -- result back to the pair-congruence's instance
+        let vExp = fromMaybe (substTy b (Ext Id u))
+                     (snd <$> witEl sig ctx wV)
+        (dc0, v', chTy) <- rePlaceE sig ctx step d p vExp v Nothing (Just wV)
         dc <- dbg "wit: pair1 eqAtLem miss" (eqAtLem sig ctx dc0 chTy (substTy b (Ext Id u)))
         pure (DElPairCong (DElRefl wU) wB dc, SigmaIntro u v', Ty.SigmaTy a b))
       <|> (do
@@ -3556,12 +3609,41 @@ lemmaInsts sig ctx step d pool0 (xN, yN) =
                 (DElTrans dR (DNfExpand (DPresupElR dR)))
     pure (dRN, leN, reN, t, p')
 
-sigLawInsts sig ctx (xa, ya) = concatMap tryEntry (toList sig)
+-- the signature's law statements, nf'd once per signature LENGTH
+-- (Σ only grows): re-normalizing every law at every closeAt call was
+-- a measured 3x on the meter
+%noinline
+sigLawTbl : IORef (Integer, List (SigIdentifier, Nat, Elem, Elem))
+sigLawTbl = mkRef 23 (-1, [])
+
+sigLawPats : Sig -> List (SigIdentifier, Nat, Elem, Elem)
+sigLawPats sig = unsafePerformIO $ do
+  (n, cached) <- readIORef sigLawTbl
+  let m = the Integer (cast (length (toList sig)))
+  if n == m
+    then pure cached
+    else do
+      let fresh = mapMaybe pat (toList sig)
+      writeIORef sigLawTbl (m, fresh)
+      pure fresh
  where
   stripPis : Ty -> (Nat, Ty)
   stripPis (Ty.PiTy _ b) = let (k, r) = stripPis b in (S k, r)
   stripPis t = (Z, t)
 
+  pat : SigEntry -> Maybe (SigIdentifier, Nat, Elem, Elem)
+  pat (SigDef [<] nm _ dty) =
+    let (nPi, body) = stripPis dty in
+    case (nPi, body) of
+      (S _, Prf (Elem.EqTy lhs rhs _)) =>
+        Just (nm, nPi,
+              fromMaybe lhs (nfE sig lhs),
+              fromMaybe rhs (nfE sig rhs))
+      _ => Nothing
+  pat _ = Nothing
+
+sigLawInsts sig ctx (xa, ya) = concatMap tryLaw (sigLawPats sig)
+ where
   mk : SigIdentifier -> List Elem -> Maybe (Elem, Elem, Deriv)
   mk nm args = do
     let pf = foldl PiApp (Elem.SigVar nm [<]) args
@@ -3579,18 +3661,11 @@ sigLawInsts sig ctx (xa, ya) = concatMap tryEntry (toList sig)
           DElTrans (DElSym (DNfExpand (DPresupElL dR)))
             (DElTrans dR (DNfExpand (DPresupElR dR))))
 
-  tryEntry : SigEntry -> List (Elem, Elem, Deriv)
-  tryEntry (SigDef [<] nm _ dty) =
-    let (nPi, body) = stripPis dty in
-    case body of
-      Prf (Elem.EqTy lhs rhs _) =>
-        let lhsN = fromMaybe lhs (nfE sig lhs)
-            rhsN = fromMaybe rhs (nfE sig rhs) in
-        mapMaybe (mk nm)
-          (nub (mapMaybe (\(pt, tg) => matchStTuple nPi pt tg)
-                  [(lhsN, xa), (lhsN, ya), (rhsN, xa), (rhsN, ya)]))
-      _ => []
-  tryEntry _ = []
+  tryLaw : (SigIdentifier, Nat, Elem, Elem) -> List (Elem, Elem, Deriv)
+  tryLaw (nm, nPi, lhsN, rhsN) =
+    mapMaybe (mk nm)
+      (nub (mapMaybe (\(pt, tg) => matchStTuple nPi pt tg)
+              [(lhsN, xa), (lhsN, ya), (rhsN, xa), (rhsN, ya)]))
 
 lemmaLeafB : Sig -> Ctx -> Step -> Nat -> Elem -> Elem -> Maybe (Deriv, Ty)
 
@@ -4244,7 +4319,7 @@ reEqEndsGo sig ctx cert l r ty ends =
   lookupEqDeriv sig ctx l r ty <|> reEqEndsGoB sig ctx cert l r ty ends
 
 reEqEndsGoB sig ctx (MkECertF tyEx steps0 final posSteps) l r ty ends =
-  restoreWitAfter (readChainWit ()) $
+  restoreWitAfter (readChainWit (), readLicPool ()) $
   setLicPool (steps0 ++ posSteps ++ (case tyEx of
                                        Just (_, certT) => certT.steps
                                        Nothing => [])) >>= \_ =>

--- a/src/idris/Nova/Kernel/Reconstruct.idr
+++ b/src/idris/Nova/Kernel/Reconstruct.idr
@@ -3742,6 +3742,61 @@ birthPiE sig ctx a b f e = unsafePerformIO $ do
       pure (if reconDebug then trace "el: piE born" (PiApp f e) else PiApp f e)
     Nothing => pure (PiApp f e)
 
+||| A pair's typing at its checked Σ (el-sigma-i).
+export
+%noinline
+birthSigmaI : Sig -> Ctx -> Ty -> Ty -> Elem -> Elem -> Elem
+birthSigmaI sig ctx a b u v = unsafePerformIO $ do
+  let False = candPosOver 150 (SigmaIntro u v)
+    | True => pure (SigmaIntro u v)
+  _ <- writeIORef workBudget 600
+  let mder = do du <- reCheck sig ctx u a emptySkel
+                db <- reTy sig (ctx :< a) b emptySkel
+                dv <- reCheck sig ctx v (substTy b (Ext Id u)) emptySkel
+                pure (DElSigmaI du db dv)
+  case mder of
+    Just d => do
+      _ <- storeElDeriv ctx (SigmaIntro u v) (Ty.SigmaTy a b) d
+      pure (if reconDebug then trace "el: sigI born" (SigmaIntro u v) else SigmaIntro u v)
+    Nothing => pure (SigmaIntro u v)
+
+||| A projection's typing at its scrutinee's exposed Σ.
+export
+%noinline
+birthProj : Sig -> Ctx -> Bool -> Ty -> Ty -> Elem -> Elem
+birthProj sig ctx first a b t = unsafePerformIO $ do
+  let e = if first then SigmaElim1 t else SigmaElim2 t
+  let concl = if first then a else substTy b (Ext Id (SigmaElim1 t))
+  let False = candPosOver 150 e
+    | True => pure e
+  _ <- writeIORef workBudget 600
+  let mder = do dt <- reCheck sig ctx t (Ty.SigmaTy a b) emptySkel
+                pure (if first then DElSigmaE1 dt else DElSigmaE2 dt)
+  case mder of
+    Just d => do
+      _ <- storeElDeriv ctx e concl d
+      pure (if reconDebug then trace "el: proj born" e else e)
+    Nothing => pure e
+
+||| A let's typing (el-let): the body's judgment lives under the
+||| value and its unfolding hypothesis.
+export
+%noinline
+birthLet : Sig -> Ctx -> Ty -> Ty -> Elem -> Elem -> Elem
+birthLet sig ctx eTy bTy e b = unsafePerformIO $ do
+  let False = candPosOver 150 (Let e b)
+    | True => pure (Let e b)
+  _ <- writeIORef workBudget 600
+  let hyp = Prf (Elem.EqTy (CtxVar 0) (substElem e Wk) (substTy eTy Wk))
+  let mder = do de <- reCheck sig ctx e eTy emptySkel
+                db <- reCheck sig (ctx :< eTy :< hyp) b bTy emptySkel
+                pure (DElLet de db)
+  case mder of
+    Just d => do
+      _ <- storeElDeriv ctx (Let e b) (substTy bTy (Ext (Ext Id e) Star)) d
+      pure (if reconDebug then trace "el: let born" (Let e b) else Let e b)
+    Nothing => pure (Let e b)
+
 ||| The type-equation twin of birthEqDeriv.
 export
 %noinline

--- a/src/idris/Nova/Kernel/Reconstruct.idr
+++ b/src/idris/Nova/Kernel/Reconstruct.idr
@@ -3548,6 +3548,56 @@ birthNatE sig ctx mot z s t = unsafePerformIO $ do
       pure (if reconDebug then trace "el: natE born" (NatElim z s t) else NatElim z s t)
     Nothing => pure (NatElim z s t)
 
+||| ⊎-elim's typing, the same move as birthNatE.
+export
+%noinline
+birthSumE : Sig -> Ctx -> Ty -> Ty -> Ty -> Elem -> Elem -> Elem -> Elem
+birthSumE sig ctx a b mot l r t = unsafePerformIO $ do
+  _ <- writeIORef workBudget 100000
+  let concl = substTy mot (Ext Id t)
+  let mder = do dt <- reCheck sig ctx t (Ty.SumTy a b) emptySkel
+                dmot <- reTy sig (ctx :< Ty.SumTy a b) mot emptySkel
+                dl <- reCheck sig (ctx :< a) l (substTy mot (Ext Wk (Inj1 (CtxVar 0)))) emptySkel
+                dr <- reCheck sig (ctx :< b) r (substTy mot (Ext Wk (Inj2 (CtxVar 0)))) emptySkel
+                let d = DElSumE dt dmot dl dr
+                let True = concludesEl sig ctx d (SumElim l r t) concl
+                  | False => Nothing
+                pure d
+  case mder of
+    Just d => do
+      _ <- storeElDeriv ctx (SumElim l r t) concl d
+      pure (if reconDebug then trace "el: sumE born" (SumElim l r t) else SumElim l r t)
+    Nothing => pure (SumElim l r t)
+
+||| quot-elim's typing: the well-definedness premise is an EQUATION
+||| the same site just discharged, so it comes from the equation
+||| store (or its certificate through the translator, once).
+export
+%noinline
+birthQuotE : Sig -> Ctx -> Ty -> Elem -> Ty -> Elem -> Elem -> ECert -> Elem
+birthQuotE sig ctx a rel mot f q wd = unsafePerformIO $ do
+  _ <- writeIORef workBudget 100000
+  let concl = substTy mot (Ext Id q)
+  let wk3 = Chain Wk (Chain Wk Wk)
+  let wdCtx = ctx :< a :< substTy a Wk :< Prf rel
+  let wdL = substElem f (Ext wk3 (CtxVar 2))
+  let wdR = substElem f (Ext wk3 (CtxVar 1))
+  let wdTy = substTy mot (Ext wk3 (Class (CtxVar 2)))
+  let mder = do dq <- reCheck sig ctx q (Ty.Quotient a rel) emptySkel
+                dmot <- reTy sig (ctx :< Ty.Quotient a rel) mot emptySkel
+                df <- reCheck sig (ctx :< a) f (substTy mot (Ext Wk (Class (CtxVar 0)))) emptySkel
+                dresp <- lookupEqDeriv sig wdCtx wdL wdR wdTy
+                         <|> reEqStar sig wdCtx wd wdL wdR wdTy Nothing
+                let d = DElQuotE dq dmot df dresp
+                let True = concludesEl sig ctx d (QuotElim f q) concl
+                  | False => Nothing
+                pure d
+  case mder of
+    Just d => do
+      _ <- storeElDeriv ctx (QuotElim f q) concl d
+      pure (if reconDebug then trace "el: quotE born" (QuotElim f q) else QuotElim f q)
+    Nothing => pure (QuotElim f q)
+
 ||| The type-equation twin of birthEqDeriv.
 export
 %noinline

--- a/src/idris/Nova/Kernel/Reconstruct.idr
+++ b/src/idris/Nova/Kernel/Reconstruct.idr
@@ -393,6 +393,57 @@ storedEl = mkTable 12
 validated : IORef (SortedMap Integer (List Integer))
 validated = mkTable 13
 
+%noinline
+mkRef : Integer -> a -> IORef a
+mkRef _ v = unsafePerformIO (newIORef v)
+
+-- ===== sharing (DShare/DRef) at the seat =====
+--
+-- During the BODY emission, a store hit is served as a CITATION into
+-- the item's share registry instead of an embedded tree; emitDef
+-- wraps the finished body in the registry's DShare chain, so replay
+-- concludes each consumed derivation once however many times the
+-- body cites it. Births run with sharing off — store entries stay
+-- self-contained.
+
+%noinline
+shareReg : IORef (SnocList (Ctx, Deriv))
+shareReg = mkRef 14 [<]
+
+%noinline
+shareIdxTbl : IORef (SortedMap Integer (List (Integer, Nat)))
+shareIdxTbl = mkTable 15
+
+%noinline
+sharingOn : IORef Bool
+sharingOn = mkRef 16 False
+
+serveShared : (Integer, Integer) -> Ctx -> Deriv -> IO Deriv
+serveShared (h1, h2) cx d = do
+  True <- readIORef sharingOn
+    | False => pure d
+  m <- readIORef shareIdxTbl
+  case lookup h2 (fromMaybe [] (lookup h1 m)) of
+    Just i => pure (DRef i)
+    Nothing => do
+      reg <- readIORef shareReg
+      let i = length (toList reg)
+      writeIORef shareReg (reg :< (cx, d))
+      modifyIORef shareIdxTbl (\m' => insert h1 ((h2, i) :: fromMaybe [] (lookup h1 m')) m')
+      pure (DRef i)
+
+%noinline
+setSharing : Bool -> Maybe ()
+setSharing b = unsafePerformIO $ do
+  writeIORef sharingOn b
+  pure (Just ())
+
+%noinline
+wrapShares : Deriv -> Deriv
+wrapShares body = unsafePerformIO $ do
+  reg <- readIORef shareReg
+  pure (foldr (\(cx, d), acc => DShare cx d acc) body (toList reg))
+
 isValidated : (Integer, Integer) -> Bool
 isValidated (h1, h2) = unsafePerformIO $ do
   m <- readIORef validated
@@ -420,11 +471,12 @@ lookupElDeriv sig ctx e ty = unsafePerformIO $ do
   case lookup h2 (fromMaybe [] (lookup h1 m)) of
     Just d =>
       if isValidated (h1 + 63, h2)
-        then pure (Just d)
+        then Just <$> serveShared (h1, h2) ctx d
         else if concludesEl sig ctx d e ty
           then do
             _ <- markValidated (h1 + 63, h2)
-            pure (if reconDebug then trace "el: stored deriv used" (Just d) else Just d)
+            d' <- serveShared (h1, h2) ctx d
+            pure (if reconDebug then trace "el: stored deriv used" (Just d') else Just d')
           else pure (if reconDebug then trace "el: stored deriv stale" Nothing else Nothing)
     Nothing => pure Nothing
 
@@ -455,11 +507,12 @@ lookupTyEqDeriv sig ctx a b = unsafePerformIO $ do
   case lookup h2 (fromMaybe [] (lookup h1 m)) of
     Just d =>
       if isValidated (h1 + 21, h2)
-        then pure (Just d)
+        then Just <$> serveShared (h1 + 9, h2) ctx d
         else if concludesTyEq sig ctx d a b
           then do
             _ <- markValidated (h1 + 21, h2)
-            pure (if reconDebug then trace "eq: stored ty-deriv used" (Just d) else Just d)
+            d' <- serveShared (h1 + 9, h2) ctx d
+            pure (if reconDebug then trace "eq: stored ty-deriv used" (Just d') else Just d')
           else pure Nothing
     Nothing => pure Nothing
 
@@ -470,11 +523,12 @@ lookupEqDeriv sig ctx l r ty = unsafePerformIO $ do
   case lookup h2 (fromMaybe [] (lookup h1 m)) of
     Just d =>
       if isValidated (h1 + 7, h2)
-        then pure (Just d)
+        then Just <$> serveShared (h1 + 3, h2) ctx d
         else if concludesEq sig ctx d l r ty
           then do
             _ <- markValidated (h1 + 7, h2)
-            pure (if reconDebug then trace "eq: stored deriv used" (Just d) else Just d)
+            d' <- serveShared (h1 + 3, h2) ctx d
+            pure (if reconDebug then trace "eq: stored deriv used" (Just d') else Just d')
           else pure (if reconDebug then trace "eq: stored deriv stale" Nothing else Nothing)
     Nothing => pure Nothing
 
@@ -530,6 +584,9 @@ withMemo ref k act = unsafePerformIO $ do
 
 resetMemosIO : IO ()
 resetMemosIO = do
+  writeIORef shareReg [<]
+  writeIORef shareIdxTbl empty
+  writeIORef sharingOn False
   writeIORef workBudget 400000
   writeIORef memoNfE empty
   writeIORef memoNfT empty
@@ -3643,6 +3700,48 @@ birthQuotE sig ctx a rel mot f q wd = unsafePerformIO $ do
       pure (if reconDebug then trace "el: quotE born" (QuotElim f q) else QuotElim f q)
     Nothing => pure (QuotElim f q)
 
+||| A λ's typing at its checked Π (el-pi-i): the body's judgment
+||| composes from the store as its own nodes birth.
+export
+%noinline
+birthPiI : Sig -> Ctx -> Ty -> Ty -> Elem -> Elem
+birthPiI sig ctx a b body = unsafePerformIO $ do
+  -- keying is structural: hashing every node's whole subtree is
+  -- quadratic over an item — only small nodes birth (they carry the
+  -- consumption anyway)
+  let False = candPosOver 150 body
+    | True => pure (PiIntro body)
+  _ <- writeIORef workBudget 600
+  let mder = do da <- reTy sig ctx a emptySkel
+                db <- reCheck sig (ctx :< a) body b emptySkel
+                pure (DElPiI da db)
+  case mder of
+    Just d => do
+      _ <- storeElDeriv ctx (PiIntro body) (Ty.PiTy a b) d
+      pure (if reconDebug then trace "el: piI born" (PiIntro body) else PiIntro body)
+    Nothing => pure (PiIntro body)
+
+||| An application's typing at the function's exposed Π (el-pi-e).
+export
+%noinline
+birthPiE : Sig -> Ctx -> Ty -> Ty -> Elem -> Elem -> Elem
+birthPiE sig ctx a b f e = unsafePerformIO $ do
+  let False = candPosOver 150 (PiApp f e)
+    | True => pure (PiApp f e)
+  -- the spine fires per node: a small budget makes a store-served
+  -- birth cheap and a reconstruction-shaped one bail immediately
+  _ <- writeIORef workBudget 600
+  let concl = substTy b (Ext Id e)
+  let mder = do df <- reCheck sig ctx f (Ty.PiTy a b) emptySkel
+                de <- reCheck sig ctx e a emptySkel
+                db <- reTy sig (ctx :< a) b emptySkel
+                pure (DElPiE df de db)
+  case mder of
+    Just d => do
+      _ <- storeElDeriv ctx (PiApp f e) concl d
+      pure (if reconDebug then trace "el: piE born" (PiApp f e) else PiApp f e)
+    Nothing => pure (PiApp f e)
+
 ||| The type-equation twin of birthEqDeriv.
 export
 %noinline
@@ -3675,7 +3774,12 @@ emitDef sig art =
     [] => do
       _ <- clearMemos ()
       dT <- dbg "emit: type" (reTy sig [<] art.dty art.dtySkel)
-      dt <- emitBody sig [<] art.body art.dty art.bodySkel dT
+      -- store hits during the BODY emission are served as citations;
+      -- the finished body wraps in the registry's DShare chain
+      _ <- setSharing True
+      dt0 <- emitBody sig [<] art.body art.dty art.bodySkel dT
+      let dt = wrapShares dt0
+      _ <- setSharing False
       pure (dT, dt)
     _ => Nothing
 

--- a/src/idris/Nova/Kernel/Reconstruct.idr
+++ b/src/idris/Nova/Kernel/Reconstruct.idr
@@ -418,6 +418,19 @@ shareIdxTbl = mkTable 15
 sharingOn : IORef Bool
 sharingOn = mkRef 16 False
 
+-- the current equation's license pool, for placement-level bridging
+-- (a lemma rewrite inside an argument shifts its type by an index
+-- law whose instance the certificate recorded)
+%noinline
+licPoolRef : IORef (List Step)
+licPoolRef = mkRef 19 []
+
+%noinline
+setLicPool : List Step -> Maybe ()
+setLicPool ps = unsafePerformIO $ do
+  writeIORef licPoolRef ps
+  pure (Just ())
+
 serveShared : (Integer, Integer) -> Ctx -> Deriv -> IO Deriv
 serveShared (h1, h2) cx d = do
   True <- readIORef sharingOn
@@ -1980,6 +1993,216 @@ reBridgeTSearch : Sig -> Ctx -> Step -> Nat -> Ty -> Ty -> Maybe Deriv
 
 ||| Coerce an element-equation derivation from its own type spelling
 ||| to a target spelling, the two nf-equal (the oracle bridge).
+-- two codes that differ by index laws meet by RECORDED lemma
+-- instances placed at prefixes of their disagreement (one per
+-- side, bounded recursion). The pool's steps are fully
+-- instantiated licenses — the certificate and its type-expansion
+-- recorded them — so matching is EXACT comparison of their
+-- licensed sides against the differing subpair: no
+-- re-instantiation, no enumeration. The congruence walk crosses
+-- only code spellings, whose motives are constant.
+stKey : Maybe Step -> String
+stKey Nothing = "-"
+stKey (Just st) =
+  show st.path ++ show st.flip ++ show st.onLhs ++
+  (case st.lic of
+     LProof pf => show pf
+     LBeta => "|β"
+     LPath _ k th => "|π\{show k}\{show (toList th)}")
+
+lemBridgeT : Sig -> Ctx -> List Step -> Nat -> Ty -> Ty -> Maybe Deriv
+lemBridgeT _ _ _ Z _ _ = Nothing
+lemBridgeT sig ctx pool (S fuel) (El x) (El y) =
+  if x == y
+    then DTyRefl <$> reTy sig ctx (El x) emptySkel
+    else do
+      -- the pool is tiny and fully instantiated: no matches means
+      -- no bridge, decided before anything walks or checks
+      let is = recInsts
+      let False = null is
+        | True => Nothing
+      withMemo memoLB "\{show (length (toList ctx))}|LB|\{concatMap (stKey . Just) pool}|\{show x}=\{show y}" $ do
+        dq <- diffPosE sig 64 [] x y
+        goPre is (reverse (inits dq))
+ where
+  -- each pool step's licensed equation, at both its normalized and
+  -- statement spellings, with its DERIVATION — matching is exact
+  -- comparison, placement is direct congruence assembly
+  recInsts : List (Elem, Elem, Deriv)
+  recInsts =
+    concatMap (\st =>
+      case st.lic of
+        LProof _ =>
+          (case reLicensed sig ctx st 0 of
+             Just (dEq, le, re, _) => [(le, re, dEq)]
+             Nothing => [])
+          ++ (case reLicensedRaw sig ctx st 0 of
+                Just (dEq, le, re, _) => [(le, re, dEq)]
+                Nothing => [])
+        _ => []) pool
+
+  -- congruence along a CODE path, assembled directly: every node
+  -- on the way lives at a closed constant type (𝕌 or ℕ), so the
+  -- eliminator congruences take the constant motive and no bridge,
+  -- no motive guess, and no search can arise
+  codeCongAt : Nat -> Ctx -> Ty -> List Nat -> Elem -> Deriv -> Maybe Deriv
+  codeCongAt Z _ _ _ _ _ = Nothing
+  codeCongAt (S f) cx exp [] z dEq = Just dEq
+  codeCongAt (S f) cx exp (i :: rest) z dEq =
+    case (z, i) of
+      (NatIntro1 u, 0) => do
+        dc <- codeCongAt f cx Ty.NatTy rest u dEq
+        pure (DElSucCong dc)
+      (NatElim zb sb t, 2) => do
+        let mot = substTy exp Wk
+        dmot <- reTy sig (cx :< Ty.NatTy) mot emptySkel
+        dz <- reCheck sig cx zb (substTy mot (Ext Id NatIntro0)) emptySkel
+        ds <- reCheck sig (cx :< Ty.NatTy :< mot) sb
+                (substTy mot (Chain (Ext Wk (NatIntro1 (CtxVar 0))) Wk)) emptySkel
+        dc <- codeCongAt f cx Ty.NatTy rest t dEq
+        pure (DElNatECong dmot (DElRefl dz) (DElRefl ds) dc)
+      (NatElim zb sb t, 0) => do
+        let mot = substTy exp Wk
+        dmot <- reTy sig (cx :< Ty.NatTy) mot emptySkel
+        ds <- reCheck sig (cx :< Ty.NatTy :< mot) sb
+                (substTy mot (Chain (Ext Wk (NatIntro1 (CtxVar 0))) Wk)) emptySkel
+        dt <- reCheck sig cx t Ty.NatTy emptySkel
+        dc <- codeCongAt f cx (substTy mot (Ext Id NatIntro0)) rest zb dEq
+        pure (DElNatECong dmot dc (DElRefl ds) (DElRefl dt))
+      (NatElim zb sb t, 1) => do
+        let mot = substTy exp Wk
+        dmot <- reTy sig (cx :< Ty.NatTy) mot emptySkel
+        dz <- reCheck sig cx zb (substTy mot (Ext Id NatIntro0)) emptySkel
+        dt <- reCheck sig cx t Ty.NatTy emptySkel
+        dc <- codeCongAt f (cx :< Ty.NatTy :< mot)
+                (substTy mot (Chain (Ext Wk (NatIntro1 (CtxVar 0))) Wk)) rest sb dEq
+        pure (DElNatECong dmot (DElRefl dz) dc (DElRefl dt))
+      _ => Nothing
+
+  place : List Nat -> Elem -> Deriv -> Elem -> Maybe (Deriv, Elem)
+  place p z dEq re = do
+    d <- codeCongAt 32 ctx Ty.UniverseTy p z dEq
+    z' <- replaceAtE p re z
+    pure (d, z')
+
+  closeAt : List (Elem, Elem, Deriv) -> Bool -> List Nat -> Maybe Deriv
+  closeAt recIs deepest p = do
+    Left xa <- subAtE p x
+      | _ => Nothing
+    Left ya <- subAtE p y
+      | _ => Nothing
+    let False = xa == ya
+      | True => Nothing
+    fullClose xa ya recIs
+      <|> (do -- one-sided steps: only at the DEEPEST disagreement
+              -- (recursion at every prefix branches exponentially)
+              let True = deepest
+                | False => Nothing
+              (dEq, re) <- pickBy xa recIs
+              (dc, x') <- place p x dEq re
+              let False = x' == x
+                | True => Nothing
+              rec <- lemBridgeT sig ctx pool fuel (El x') (El y)
+              pure (DTyTrans (DTyElCong dc) rec))
+      <|> (do let True = deepest
+                | False => Nothing
+              (dEq, re) <- pickBy ya recIs
+              (dc, y') <- place p y dEq re
+              let False = y' == y
+                | True => Nothing
+              rec <- lemBridgeT sig ctx pool fuel (El x) (El y')
+              pure (DTyTrans rec (DTySym (DTyElCong dc))))
+   where
+    fullClose : Elem -> Elem -> List (Elem, Elem, Deriv) -> Maybe Deriv
+    fullClose xa ya [] = Nothing
+    fullClose xa ya ((leN, reN, dEq) :: more) =
+      (do let True = leN == xa && reN == ya
+            | False => Nothing
+          (dc, x') <- place p x dEq reN
+          let True = x' == y
+            | False => Nothing
+          pure (DTyElCong dc))
+      <|> (do let True = reN == xa && leN == ya
+                | False => Nothing
+              (dc, x') <- place p x (DElSym dEq) leN
+              let True = x' == y
+                | False => Nothing
+              pure (DTyElCong dc))
+      <|> fullClose xa ya more
+
+    pickBy : Elem -> List (Elem, Elem, Deriv) -> Maybe (Deriv, Elem)
+    pickBy za [] = Nothing
+    pickBy za ((leN, reN, dEq) :: more) =
+      if leN == za then Just (dEq, reN)
+      else if reN == za then Just (DElSym dEq, leN)
+      else pickBy za more
+
+  -- the prefix list arrives deepest-first: one-sided recursion is
+  -- allowed only at its head
+  goPre : List (Elem, Elem, Deriv) -> List (List Nat) -> Maybe Deriv
+  goPre recIs [] = Nothing
+  goPre recIs (p :: ps) = closeAt recIs True p <|> goRest ps
+   where
+    goRest : List (List Nat) -> Maybe Deriv
+    goRest [] = Nothing
+    goRest (q :: qs) = closeAt recIs False q <|> goRest qs
+-- one side El, the other an EXPOSED former: the unfolding is
+-- blocked behind an index law — rewrite the code by a recorded
+-- instance at an exact occurrence, then close through the oracle
+lemBridgeT sig ctx pool (S fuel) (El x) b = goPool pool
+ where
+  firstPosG : Elem -> Elem -> Maybe (List Nat)
+  firstPosG le z = goP (snd (candPosB 160 [] z))
+   where
+    goP : List (List Nat) -> Maybe (List Nat)
+    goP [] = Nothing
+    goP (q :: qs) =
+      case subAtE q z of
+        Just (Left sub) => if sub == le then Just q else goP qs
+        _ => goP qs
+
+  codeCongG : Nat -> Ctx -> Ty -> List Nat -> Elem -> Deriv -> Maybe Deriv
+  codeCongG Z _ _ _ _ _ = Nothing
+  codeCongG (S f) cx exp [] z dEq = Just dEq
+  codeCongG (S f) cx exp (i :: rest) z dEq =
+    case (z, i) of
+      (NatIntro1 u, 0) => DElSucCong <$> codeCongG f cx Ty.NatTy rest u dEq
+      (NatElim zb sb t, 2) => do
+        let mot = substTy exp Wk
+        dmot <- reTy sig (cx :< Ty.NatTy) mot emptySkel
+        dz <- reCheck sig cx zb (substTy mot (Ext Id NatIntro0)) emptySkel
+        ds <- reCheck sig (cx :< Ty.NatTy :< mot) sb
+                (substTy mot (Chain (Ext Wk (NatIntro1 (CtxVar 0))) Wk)) emptySkel
+        dc <- codeCongG f cx Ty.NatTy rest t dEq
+        pure (DElNatECong dmot (DElRefl dz) (DElRefl ds) dc)
+      _ => Nothing
+
+  tryInst : Deriv -> Elem -> Elem -> Maybe Deriv
+  tryInst dEq le re = do
+    q <- firstPosG le x
+    dc <- codeCongG 32 ctx Ty.UniverseTy q x dEq
+    x' <- replaceAtE q re x
+    xN <- nfT sig (El x')
+    bN <- nfT sig b
+    let dEl = DTyElCong dc
+    if xN == bN
+      then do
+        dB <- lookupTyDeriv sig ctx b <|> reTy sig ctx b emptySkel
+        pure (DTyTrans dEl (DNfEqTy (DPresupTyR dEl) dB))
+      else do
+        rec <- lemBridgeT sig ctx pool fuel (El x') b
+        pure (DTyTrans dEl rec)
+
+  goPool : List Step -> Maybe Deriv
+  goPool [] = Nothing
+  goPool (st :: rest) =
+    (do (dEq, le, re, _) <- reLicensed sig ctx st 0
+        tryInst dEq le re <|> tryInst (DElSym dEq) re le)
+    <|> (do (dEq, le, re, _) <- reLicensedRaw sig ctx st 0
+            tryInst dEq le re <|> tryInst (DElSym dEq) re le)
+    <|> goPool rest
+lemBridgeT _ _ _ _ _ _ = Nothing
+
 eqAtNf : Sig -> Ctx -> Deriv -> Ty -> Ty -> Maybe Deriv
 eqAtNf sig ctx dEq cur tgt =
   if cur == tgt then Just dEq
@@ -1991,6 +2214,25 @@ eqAtNf sig ctx dEq cur tgt =
       dC <- reTy sig ctx cur emptySkel
       dT <- reTy sig ctx tgt emptySkel
       pure (DElEqTyCoe (DNfEqTy dC dT) dEq)
+
+||| … and past nf: a DEPENDENT SHIFT between the spellings, closed by
+||| the recorded-instance bridge over the current equation's license
+||| pool (an argument's inner rewrite shifts its type by an index law
+||| the certificate carries).
+eqAtLem : Sig -> Ctx -> Deriv -> Ty -> Ty -> Maybe Deriv
+eqAtLem sig ctx dEq cur tgt =
+  eqAtNf sig ctx dEq cur tgt
+  <|> do
+    let pool@(_ :: _) = unsafePerformIO (readIORef licPoolRef)
+      | [] => Nothing
+    cN <- nfT sig cur
+    tN <- nfT sig tgt
+    dBr <- lemBridgeT sig ctx pool 3 cN tN
+    dT <- lookupTyDeriv sig ctx tgt <|> reTy sig ctx tgt emptySkel
+    let dCur = DPresupElTy (DPresupElL dEq)
+    let dCN = DPresupTyR (DNfExpandTy dCur)
+    let atN = DElEqTyCoe dBr (DElEqTyCoe (DNfEqTy dCur dCN) dEq)
+    pure (DElEqTyCoe (DTySym (DNfExpandTy dT)) atN)
 
 ||| Placement: rewrite `cur` at `path` by the step's licensed
 ||| equation, emitting the congruence chain; returns the derivation
@@ -2034,27 +2276,36 @@ rePlaceE sig ctx step d [] exp cur mty =
                pure (DElTrans (DElSym dch) dEq0)
     d' <- if t == exp then Just dEq
           else do
-            -- only a β-bridge: a position whose type differs from the
-            -- licensed type beyond nf (a dependent position shifted by
-            -- an earlier rewrite) is outside this slice
             tN <- nfT sig t
             eN <- nfT sig exp
-            let True = tN == eN
-              | False => Nothing
-            dt <- reTy sig ctx t emptySkel
-            de <- reTy sig ctx exp emptySkel
-            pure (DElEqTyCoe (DNfEqTy dt de) dEq)
+            if tN == eN
+              then do
+                dt <- reTy sig ctx t emptySkel
+                de <- reTy sig ctx exp emptySkel
+                pure (DElEqTyCoe (DNfEqTy dt de) dEq)
+              else do
+                -- a dependent position shifted by an earlier rewrite:
+                -- the recorded-instance bridge over the equation's
+                -- license pool closes what nf cannot
+                let pool@(_ :: _) = unsafePerformIO (readIORef licPoolRef)
+                  | [] => Nothing
+                dBr <- lemBridgeT sig ctx pool 3 tN eN
+                dE <- lookupTyDeriv sig ctx exp <|> reTy sig ctx exp emptySkel
+                let dT = DPresupElTy (DPresupElL dEq)
+                let dTN = DPresupTyR (DNfExpandTy dT)
+                let atN = DElEqTyCoe dBr (DElEqTyCoe (DNfEqTy dT dTN) dEq)
+                pure (DElEqTyCoe (DTySym (DNfExpandTy dE)) atN)
     pure (d', re, if t == exp then t else exp)
 rePlaceE sig ctx step d (i :: p) exp cur mty =
   case (cur, i) of
     (NatIntro1 t, 0) => do
       (dc0, t', chTy) <- rePlaceE sig ctx step d p Ty.NatTy t Nothing
-      dc <- eqAtNf sig ctx dc0 chTy Ty.NatTy
+      dc <- eqAtLem sig ctx dc0 chTy Ty.NatTy
       pure (DElSucCong dc, NatIntro1 t', Ty.NatTy)
     (PiApp f e, 0) => do
       (a, b) <- headPi sig ctx f e exp
       (dc0, f', chTy) <- rePlaceE sig ctx step d p (Ty.PiTy a b) f Nothing
-      dc <- eqAtNf sig ctx dc0 chTy (Ty.PiTy a b)
+      dc <- eqAtLem sig ctx dc0 chTy (Ty.PiTy a b)
       de <- reCheck sig ctx e a emptySkel
       db <- reTy sig (ctx :< a) b emptySkel
             <|> Just (DInvPiCod (DPresupElTy (DPresupElL dc)))
@@ -2063,7 +2314,7 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
       (a, b) <- headPi sig ctx f e exp
       df <- reCheck sig ctx f (Ty.PiTy a b) emptySkel
       (dc0, e', chTy) <- rePlaceE sig ctx step d p a e Nothing
-      dc <- eqAtNf sig ctx dc0 chTy a
+      dc <- eqAtLem sig ctx dc0 chTy a
       db <- reTy sig (ctx :< a) b emptySkel
             <|> Just (DInvPiCod (DPresupElTy df))
       -- the congruence concludes at the POST-instance B[id,e′]; the
@@ -2086,7 +2337,7 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
       let Ty.SigmaTy a b = expN
         | _ => Nothing
       (dc0, u', chTy) <- rePlaceE sig ctx step d p a u Nothing
-      dc <- eqAtNf sig ctx dc0 chTy a
+      dc <- eqAtLem sig ctx dc0 chTy a
       db <- reTy sig (ctx :< a) b emptySkel
       dv <- reCheck sig ctx v (substTy b (Ext Id u')) emptySkel
       pure (DElPairCong dc db (DElRefl dv), SigmaIntro u' v, expN)
@@ -2097,13 +2348,13 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
       du <- reCheck sig ctx u a emptySkel
       db <- reTy sig (ctx :< a) b emptySkel
       (dc0, v', chTy) <- rePlaceE sig ctx step d p (substTy b (Ext Id u)) v Nothing
-      dc <- eqAtNf sig ctx dc0 chTy (substTy b (Ext Id u))
+      dc <- eqAtLem sig ctx dc0 chTy (substTy b (Ext Id u))
       pure (DElPairCong (DElRefl du) db dc, SigmaIntro u v', expN)
     (Inj1 a, 0) =>
       case exp of
         Ty.SumTy l r => do
           (dc0, a', chTy) <- rePlaceE sig ctx step d p l a Nothing
-          dc <- eqAtNf sig ctx dc0 chTy l
+          dc <- eqAtLem sig ctx dc0 chTy l
           dr <- reTy sig ctx r emptySkel
           pure (DElInj1Cong dc dr, Inj1 a', Ty.SumTy l r)
         _ => Nothing
@@ -2111,7 +2362,7 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
       case exp of
         Ty.SumTy l r => do
           (dc0, b', chTy) <- rePlaceE sig ctx step d p r b Nothing
-          dc <- eqAtNf sig ctx dc0 chTy r
+          dc <- eqAtLem sig ctx dc0 chTy r
           dl <- reTy sig ctx l emptySkel
           pure (DElInj2Cong dc dl, Inj2 b', Ty.SumTy l r)
         _ => Nothing
@@ -2121,7 +2372,7 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
       let False = fst (candPosB 501 [] st) == 0 || tySizeFuel 501 [] exp == 0
         | True => Nothing
       (dc0, t', chTy) <- rePlaceE sig ctx step d p Ty.NatTy t Nothing
-      dc <- eqAtNf sig ctx dc0 chTy Ty.NatTy
+      dc <- eqAtLem sig ctx dc0 chTy Ty.NatTy
       let tryMot = \mot => do
             dmot <- dbg "natEmot: motive \{show mot}" (reTy sig (ctx :< Ty.NatTy) mot emptySkel)
             dz <- dbg "natEmot: z" (chkStep sig ctx step d z (substTy mot (Ext Id NatIntro0)))
@@ -2169,7 +2420,7 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
           dl <- reCheck sig (ctx :< a) l (substTy exp Wk) emptySkel
           dr <- reCheck sig (ctx :< b) r (substTy exp Wk) emptySkel
           (dc0, t', chTy) <- rePlaceE sig ctx step d p (Ty.SumTy a b) t Nothing
-          dc <- eqAtNf sig ctx dc0 chTy (Ty.SumTy a b)
+          dc <- eqAtLem sig ctx dc0 chTy (Ty.SumTy a b)
           pure (DElSumECong dc dmot (DElRefl dl) (DElRefl dr),
                 SumElim l r t', exp)
         _ => Nothing
@@ -2189,7 +2440,7 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
         | _ => Nothing
       let nuT = Ty.NuTy f
       (dc0, t', chTy) <- rePlaceE sig ctx step d p nuT t Nothing
-      dc <- eqAtNf sig ctx dc0 chTy nuT
+      dc <- eqAtLem sig ctx dc0 chTy nuT
       dNu <- reTy sig ctx nuT emptySkel
       (dSp, spTy) <- reInfer sig (ctx :< nuT) (Out (CtxVar 0)) emptySkel
       let dS = DSubExtCong (DSubRefl DSubId) dNu dc
@@ -2201,7 +2452,7 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
       let Ty.SigmaTy a _ = ttyN
         | _ => Nothing
       (dc0, t', chTy) <- rePlaceE sig ctx step d p ttyN t Nothing
-      dc <- eqAtNf sig ctx dc0 chTy ttyN
+      dc <- eqAtLem sig ctx dc0 chTy ttyN
       pure (DElProj1Cong dc, SigmaElim1 t', a)
     (SigmaElim2 t, 0) => do
       (dt, tty) <- reInfer sig ctx t emptySkel
@@ -2209,7 +2460,7 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
       let Ty.SigmaTy a b = ttyN
         | _ => Nothing
       (dc0, t', chTy) <- rePlaceE sig ctx step d p ttyN t Nothing
-      dc <- eqAtNf sig ctx dc0 chTy ttyN
+      dc <- eqAtLem sig ctx dc0 chTy ttyN
       -- shift neutralized at source, as at PiApp-1: the first
       -- projections' equation bridges B[id, π₁ t′] back to
       -- B[id, π₁ t]
@@ -2266,7 +2517,7 @@ rePlaceE sig ctx step d (i :: p) exp cur mty =
       e0 <- getAt i ls
       ety <- telInst tel i ls
       (dc0, e', chTy) <- rePlaceE sig ctx step d p ety e0 Nothing
-      dc <- eqAtNf sig ctx dc0 chTy ety
+      dc <- eqAtLem sig ctx dc0 chTy ety
       dSig <- reQSig sig ctx sg
       ds <- traverse (\(j, ej) =>
               if j == i then Just dc
@@ -2330,7 +2581,7 @@ rePlaceT sig ctx step d (i :: p) (QSort sg k es) mtf = do
   e <- getAt i l
   ety <- telInst tel i l
   (dc0, e', chTy) <- rePlaceE sig ctx step d p ety e Nothing
-  dc <- eqAtNf sig ctx dc0 chTy ety
+  dc <- eqAtLem sig ctx dc0 chTy ety
   dSig <- reQSig sig ctx sg
   ds <- traverse (\(j, ej) =>
           if j == i then Just dc
@@ -2579,14 +2830,6 @@ lemmaLeafB sig ctx step d x y = do
 ||| equation. Walk the two type spellings in parallel — α-equal parts
 ||| by refl, elements at the licensed pair by the licensed equation
 ||| itself (coerced to the position), congruence in between.
-stKey : Maybe Step -> String
-stKey Nothing = "-"
-stKey (Just st) =
-  show st.path ++ show st.flip ++ show st.onLhs ++
-  (case st.lic of
-     LProof pf => show pf
-     LBeta => "|β"
-     LPath _ k th => "|π\{show k}\{show (toList th)}")
 
 reBridgeE : Sig -> Ctx -> Maybe Step -> Nat -> Elem -> Elem -> Ty -> Maybe Deriv
 
@@ -2910,151 +3153,9 @@ stepChainE sig ctx positional allSteps ty (chain, dCur, cur) step =
     go [] = Nothing
     go (st :: rest) = f st <|> go rest
 
-  -- two codes that differ by index laws meet by RECORDED lemma
-  -- instances placed at prefixes of their disagreement (one per
-  -- side, bounded recursion). The pool's steps are fully
-  -- instantiated licenses — the certificate and its type-expansion
-  -- recorded them — so matching is EXACT comparison of their
-  -- licensed sides against the differing subpair: no
-  -- re-instantiation, no enumeration. The congruence walk crosses
-  -- only code spellings, whose motives are constant.
-  lemBridgeT : Nat -> Ty -> Ty -> Maybe Deriv
-  lemBridgeT Z _ _ = Nothing
-  lemBridgeT (S fuel) (El x) (El y) =
-    if x == y
-      then DTyRefl <$> reTy sig ctx (El x) emptySkel
-      else do
-        -- the pool is tiny and fully instantiated: no matches means
-        -- no bridge, decided before anything walks or checks
-        let is = recInsts
-        let False = null is
-          | True => Nothing
-        withMemo memoLB "\{show (length (toList ctx))}|LB|\{stKey (Just step)}|\{show x}=\{show y}" $ do
-          dq <- diffPosE sig 64 [] x y
-          goPre is (reverse (inits dq))
-   where
-    -- each pool step's licensed equation, at both its normalized and
-    -- statement spellings, with its DERIVATION — matching is exact
-    -- comparison, placement is direct congruence assembly
-    recInsts : List (Elem, Elem, Deriv)
-    recInsts =
-      concatMap (\st =>
-        case st.lic of
-          LProof _ =>
-            (case reLicensed sig ctx st 0 of
-               Just (dEq, le, re, _) => [(le, re, dEq)]
-               Nothing => [])
-            ++ (case reLicensedRaw sig ctx st 0 of
-                  Just (dEq, le, re, _) => [(le, re, dEq)]
-                  Nothing => [])
-          _ => []) (step :: allSteps)
+  -- (lemBridgeT extracted to the top level — the placement's type
+  -- reconciliation needs it too; the pool travels as a parameter)
 
-    -- congruence along a CODE path, assembled directly: every node
-    -- on the way lives at a closed constant type (𝕌 or ℕ), so the
-    -- eliminator congruences take the constant motive and no bridge,
-    -- no motive guess, and no search can arise
-    codeCongAt : Nat -> Ctx -> Ty -> List Nat -> Elem -> Deriv -> Maybe Deriv
-    codeCongAt Z _ _ _ _ _ = Nothing
-    codeCongAt (S f) cx exp [] z dEq = Just dEq
-    codeCongAt (S f) cx exp (i :: rest) z dEq =
-      case (z, i) of
-        (NatIntro1 u, 0) => do
-          dc <- codeCongAt f cx Ty.NatTy rest u dEq
-          pure (DElSucCong dc)
-        (NatElim zb sb t, 2) => do
-          let mot = substTy exp Wk
-          dmot <- reTy sig (cx :< Ty.NatTy) mot emptySkel
-          dz <- reCheck sig cx zb (substTy mot (Ext Id NatIntro0)) emptySkel
-          ds <- reCheck sig (cx :< Ty.NatTy :< mot) sb
-                  (substTy mot (Chain (Ext Wk (NatIntro1 (CtxVar 0))) Wk)) emptySkel
-          dc <- codeCongAt f cx Ty.NatTy rest t dEq
-          pure (DElNatECong dmot (DElRefl dz) (DElRefl ds) dc)
-        (NatElim zb sb t, 0) => do
-          let mot = substTy exp Wk
-          dmot <- reTy sig (cx :< Ty.NatTy) mot emptySkel
-          ds <- reCheck sig (cx :< Ty.NatTy :< mot) sb
-                  (substTy mot (Chain (Ext Wk (NatIntro1 (CtxVar 0))) Wk)) emptySkel
-          dt <- reCheck sig cx t Ty.NatTy emptySkel
-          dc <- codeCongAt f cx (substTy mot (Ext Id NatIntro0)) rest zb dEq
-          pure (DElNatECong dmot dc (DElRefl ds) (DElRefl dt))
-        (NatElim zb sb t, 1) => do
-          let mot = substTy exp Wk
-          dmot <- reTy sig (cx :< Ty.NatTy) mot emptySkel
-          dz <- reCheck sig cx zb (substTy mot (Ext Id NatIntro0)) emptySkel
-          dt <- reCheck sig cx t Ty.NatTy emptySkel
-          dc <- codeCongAt f (cx :< Ty.NatTy :< mot)
-                  (substTy mot (Chain (Ext Wk (NatIntro1 (CtxVar 0))) Wk)) rest sb dEq
-          pure (DElNatECong dmot (DElRefl dz) dc (DElRefl dt))
-        _ => Nothing
-
-    place : List Nat -> Elem -> Deriv -> Elem -> Maybe (Deriv, Elem)
-    place p z dEq re = do
-      d <- codeCongAt 32 ctx Ty.UniverseTy p z dEq
-      z' <- replaceAtE p re z
-      pure (d, z')
-
-    closeAt : List (Elem, Elem, Deriv) -> Bool -> List Nat -> Maybe Deriv
-    closeAt recIs deepest p = do
-      Left xa <- subAtE p x
-        | _ => Nothing
-      Left ya <- subAtE p y
-        | _ => Nothing
-      let False = xa == ya
-        | True => Nothing
-      fullClose xa ya recIs
-        <|> (do -- one-sided steps: only at the DEEPEST disagreement
-                -- (recursion at every prefix branches exponentially)
-                let True = deepest
-                  | False => Nothing
-                (dEq, re) <- pickBy xa recIs
-                (dc, x') <- place p x dEq re
-                let False = x' == x
-                  | True => Nothing
-                rec <- lemBridgeT fuel (El x') (El y)
-                pure (DTyTrans (DTyElCong dc) rec))
-        <|> (do let True = deepest
-                  | False => Nothing
-                (dEq, re) <- pickBy ya recIs
-                (dc, y') <- place p y dEq re
-                let False = y' == y
-                  | True => Nothing
-                rec <- lemBridgeT fuel (El x) (El y')
-                pure (DTyTrans rec (DTySym (DTyElCong dc))))
-     where
-      fullClose : Elem -> Elem -> List (Elem, Elem, Deriv) -> Maybe Deriv
-      fullClose xa ya [] = Nothing
-      fullClose xa ya ((leN, reN, dEq) :: more) =
-        (do let True = leN == xa && reN == ya
-              | False => Nothing
-            (dc, x') <- place p x dEq reN
-            let True = x' == y
-              | False => Nothing
-            pure (DTyElCong dc))
-        <|> (do let True = reN == xa && leN == ya
-                  | False => Nothing
-                (dc, x') <- place p x (DElSym dEq) leN
-                let True = x' == y
-                  | False => Nothing
-                pure (DTyElCong dc))
-        <|> fullClose xa ya more
-
-      pickBy : Elem -> List (Elem, Elem, Deriv) -> Maybe (Deriv, Elem)
-      pickBy za [] = Nothing
-      pickBy za ((leN, reN, dEq) :: more) =
-        if leN == za then Just (dEq, reN)
-        else if reN == za then Just (DElSym dEq, leN)
-        else pickBy za more
-
-    -- the prefix list arrives deepest-first: one-sided recursion is
-    -- allowed only at its head
-    goPre : List (Elem, Elem, Deriv) -> List (List Nat) -> Maybe Deriv
-    goPre recIs [] = Nothing
-    goPre recIs (p :: ps) = closeAt recIs True p <|> goRest ps
-     where
-      goRest : List (List Nat) -> Maybe Deriv
-      goRest [] = Nothing
-      goRest (q :: qs) = closeAt recIs False q <|> goRest qs
-  lemBridgeT _ _ _ = Nothing
 
   -- the placement congruence concludes at its own computed spelling
   -- of the type; bridge back to the chain's spelling when nf-equal,
@@ -3093,7 +3194,7 @@ stepChainE sig ctx positional allSteps ty (chain, dCur, cur) step =
                        -- pool instances — never the proposing search
                        let False = tySizeFuel 601 [] pN == 0
                          | True => Nothing
-                       lemBridgeT 3 pN tN
+                       lemBridgeT sig ctx (step :: allSteps) 3 pN tN
             let atN = DElEqTyCoe dBr dPlN
             pure (DElEqTyCoe (DTySym (DNfExpandTy dTy)) atN)
 
@@ -3253,6 +3354,9 @@ reEqEndsGo sig ctx cert l r ty ends =
   lookupEqDeriv sig ctx l r ty <|> reEqEndsGoB sig ctx cert l r ty ends
 
 reEqEndsGoB sig ctx (MkECertF tyEx steps0 final posSteps) l r ty ends =
+  setLicPool (steps0 ++ posSteps ++ (case tyEx of
+                                       Just (_, certT) => certT.steps
+                                       Nothing => [])) >>= \_ =>
   (if reconDebug then trace "reqe: \{show l} EQ \{show r} nsteps \{show (length steps)} tyEx \{show (maybe False (const True) tyEx)}" (Just ()) else Just ()) >>= \_ => do
   -- a POSITIONAL replay is re-expressed against the equation's own
   -- spellings at its RAW type: the recorded type-expansion belongs

--- a/src/idris/Nova/Kernel/Reconstruct.idr
+++ b/src/idris/Nova/Kernel/Reconstruct.idr
@@ -370,7 +370,7 @@ eqKey ctx l r ty =
 
 concludesEq : Sig -> Ctx -> Deriv -> Elem -> Elem -> Ty -> Bool
 concludesEq sig ctx d l r ty =
-  case runKM (conclude sig ctx d) fuelR of
+  case runKM (conclude [] sig ctx d) fuelR of
     Right (JElEq l' r' ty', _) => l' == l && r' == r && ty' == ty
     _ => False
 
@@ -409,7 +409,7 @@ elKey ctx e ty =
 
 concludesEl : Sig -> Ctx -> Deriv -> Elem -> Ty -> Bool
 concludesEl sig ctx d e ty =
-  case runKM (conclude sig ctx d) fuelR of
+  case runKM (conclude [] sig ctx d) fuelR of
     Right (JEl e' ty', _) => e' == e && ty' == ty
     _ => False
 
@@ -444,7 +444,7 @@ tyEqKey ctx a b =
 
 concludesTyEq : Sig -> Ctx -> Deriv -> Ty -> Ty -> Bool
 concludesTyEq sig ctx d a b =
-  case runKM (conclude sig ctx d) fuelR of
+  case runKM (conclude [] sig ctx d) fuelR of
     Right (JTyEq a' b', _) => a' == a && b' == b
     _ => False
 

--- a/src/idris/Nova/Kernel/Reconstruct.idr
+++ b/src/idris/Nova/Kernel/Reconstruct.idr
@@ -40,6 +40,7 @@ import Nova.Kernel.Derivation
 
 -- NOVA_RECON_DEBUG=1 prints the first-failure spine of a bailing
 -- reconstruction (untrusted diagnostics; never touches replay)
+export
 reconDebug : Bool
 reconDebug = unsafePerformIO (isJust <$> getEnv "NOVA_RECON_DEBUG")
 
@@ -4957,6 +4958,41 @@ birthPiE sig ctx a b f e = unsafePerformIO $ do
       _ <- storeElDeriv ctx (PiApp f e) concl d
       pure (if reconDebug then trace "el: piE born" (PiApp f e) else PiApp f e)
     Nothing => pure (PiApp f e)
+
+||| A judgment CONSTRUCTED by the elaborator (the port,
+||| docs/NovaPipeline.txt phase 3 end-state), stored as-is: the
+||| covered-by-construction route — no reconstruction runs at all.
+||| Optimistic like every birth; validity is checked at lookup.
+||| Identity on its last argument (dataflow-forced).
+export
+%noinline
+storeJudEl : Ctx -> Elem -> Ty -> Deriv -> a -> a
+storeJudEl ctx e ty d v = unsafePerformIO $ do
+  storeElDeriv ctx e ty d
+  pure (if reconDebug then trace "jud: constructed" v else v)
+
+||| A constructed FORMATION stored as-is (the port's counterpart of
+||| storeJudEl for types). Identity on its last argument.
+export
+%noinline
+storeJudTy : Ctx -> Ty -> Deriv -> a -> a
+storeJudTy ctx t d v = unsafePerformIO $ do
+  storeTyDeriv ctx t d
+  pure (if reconDebug then trace "jud: ty constructed" v else v)
+
+||| The stored formation for a spelling, exposed for the port's
+||| judgment threading (a def item's just-elaborated type has its
+||| birth-stored formation here) — read OPTIMISTICALLY, without
+||| validation: mid-elaboration the kernel Σ may not yet hold the
+||| hole entries the formation cites (the mirror runs later), and
+||| the composed judgment is untrusted data validated at
+||| consumption, exactly like every birth.
+export
+judStoredTy : Sig -> Ctx -> Ty -> Maybe Deriv
+judStoredTy _ ctx t = unsafePerformIO $ do
+  m <- readIORef storedTy2
+  let (h1, h2) = fmKey ctx t
+  pure (lookup h2 (fromMaybe [] (lookup h1 m)))
 
 ||| A pair's typing at its checked Σ (el-sigma-i).
 export

--- a/src/idris/Nova/Test.idr
+++ b/src/idris/Nova/Test.idr
@@ -130,6 +130,15 @@ derivCases =
       (DElNatS (DElPiE (DElPiI DTyNat (DElVar 0)) DElNatZ DTyNat)))
     -- REJECTION: the path must land on a ≜ redex
   , ("beta-at-stuck", DBetaAt [0] (DElNatS DElNatZ))
+    -- sharing: one binding, cited twice — replay concludes the
+    -- binding once
+  , ("share", DShare [<] DElNatZ
+      (DElTrans (DElRefl (DRef 0)) (DElRefl (DRef 0))))
+    -- REJECTION: a citation under a binder — the reference is legal
+    -- exactly at the binding's context
+  , ("share-wrong-ctx", DShare [<] DElNatZ (DElPiI DTyNat (DRef 0)))
+    -- REJECTION: no such binding
+  , ("share-range", DRef 5)
   ]
 
 runDerivTests : IO ()

--- a/tests/nova/derivation/deriv-core/expected
+++ b/tests/nova/derivation/deriv-core/expected
@@ -20,3 +20,6 @@ natelim-cong: ⊦ NatElim (NatIntro0) (NatIntro1 (CtxVar 1)) (NatIntro1 (NatIntr
 pi-inj-dom: ⊦ NatTy ≐ NatTy type
 beta-at: ⊦ NatIntro1 (PiApp (PiIntro (CtxVar 0)) (NatIntro0)) ≐ NatIntro1 (NatIntro0) : NatTy
 beta-at-stuck: REJECTED [derivation: beta-at: no ≜ redex at the path]
+share: ⊦ NatIntro0 ≐ NatIntro0 : NatTy
+share-wrong-ctx: REJECTED [derivation: share-ref cited outside its binding context]
+share-range: REJECTED [derivation: share-ref out of range]


### PR DESCRIPTION
Stacked on #52, which stays unmerged as the intermediate baseline: the reconstruction architecture there is scaffolding this work exists to delete, so it should not land in main — this branch builds the replacement on top of it and consumes its kernel half (the replay kernel, beta-at, the meters, the emission pass demoted to a migration adapter).

Plan of record: docs/NovaPipeline.txt, "Phase 3 end-state, revised: judgment-carrying elaboration". The elaborator's working state becomes a derivation whose erasure is the (context, element, type) triple; premise access is projection, never inversion; rewriting is demoted from mechanism to corollary (trans + congruence frames + root lemma instances, built forward by a refiner); search is erased and proposal-only; conclude remains the sole authority.

Migration is strangler-fig under the existing meters (suite 140/140, strict meter 26/27 at the baseline): elaboration routes port to Jud-valued form one at a time, unported routes keep falling to the reconstruction adapter, and the strict meter measures the port. First commit seeds Nova.Elaboration.Jud — the judgment forms, erasures, and the constructors the ⋆-discharge pilot needs.
