### PR TITLE
Web renderer: go-to-definition, statically

### DIFF
--- a/src/idris/Nova/Docs/Render.idr
+++ b/src/idris/Nova/Docs/Render.idr
@@ -7,6 +7,19 @@ module Nova.Docs.Render
 -- with one <span class="tok-..."> per classified token — so a
 -- rendered page's highlighting always matches what an editor's LSP
 -- client shows, with no separate classifier to keep in sync.
+--
+-- GO-TO-DEFINITION, statically: the same name resolution the LSP's
+-- definition request uses (Nova.LSP.Definitions — purely syntactic,
+-- built from the loaded ModUnits) turns every resolvable
+-- identifier/operator token into a link. Each rendered line carries
+-- an id ("L<n>", 1-based), so a link's target is the defining item's
+-- first line — same page as "#L37", cross-module as "nat.html#L12".
+-- A written name that resolves to nothing but names a loaded module
+-- links to that module's page (import heads navigate). Local
+-- (λ/Π-bound) names resolve to nothing and stay plain — with the
+-- LSP's own caveat that a local SHADOWING a global will link to the
+-- global; resolution is best-effort syntactic, exactly like the
+-- editor's.
 
 import Data.List
 import Data.List1
@@ -20,11 +33,14 @@ import System.File
 import Me.Russoul.Text.Range
 import Me.Russoul.Text.Position
 
+import Data.SortedMap
+
 import Nova.Kernel.Parser
 import Nova.Elaboration
 import Nova.Elaboration.Loader
 import Nova.LSP.Capabilities
 import Nova.LSP.SemanticTokens
+import Nova.LSP.Definitions
 
 %default covering
 
@@ -53,34 +69,44 @@ classFor i = fromMaybe "plain" (nth (integerToNat (cast i)) tokenTypeNames)
 ||| Render one source line against the (start-ordered) tokens whose
 ||| span begins on it, returning the line's HTML and the tokens left
 ||| over for later lines. `pos` is the codepoint column already
-||| emitted on this line.
-renderLine : (lineNo : Int) -> (pos : Int) -> List Char -> List (Range, Int)
-           -> (String, List (Range, Int))
+||| emitted on this line. A token carrying an href renders as a link
+||| instead of a span, same class either way.
+renderLine : (lineNo : Int) -> (pos : Int) -> List Char -> List (Range, Int, Maybe String)
+           -> (String, List (Range, Int, Maybe String))
 renderLine _ _ cs [] = (htmlEscape (pack cs), [])
 renderLine lineNo pos cs (tok :: rest) =
-  let (MkRange (MkPosition sl sc) (MkPosition _ ec), kind) = tok in
+  let (MkRange (MkPosition sl sc) (MkPosition _ ec), kind, mhref) = tok in
   if sl /= lineNo
     then (htmlEscape (pack cs), tok :: rest)
     else
       let (gapChars, afterGap) = splitAt (integerToNat (cast (sc - pos))) cs
           (tokChars, afterTok) = splitAt (integerToNat (cast (ec - sc))) afterGap
           gapHtml = htmlEscape (pack gapChars)
-          tokHtml = "<span class=\"tok-" ++ classFor kind ++ "\">" ++ htmlEscape (pack tokChars) ++ "</span>"
+          inner = htmlEscape (pack tokChars)
+          tokHtml = case mhref of
+                      Just href =>
+                        "<a class=\"tok-" ++ classFor kind ++ "\" href=\"" ++ href ++ "\">" ++ inner ++ "</a>"
+                      Nothing =>
+                        "<span class=\"tok-" ++ classFor kind ++ "\">" ++ inner ++ "</span>"
           (restHtml, leftover) = renderLine lineNo ec afterTok rest
       in (gapHtml ++ tokHtml ++ restHtml, leftover)
 
-renderLines : (lineNo : Int) -> List String -> List (Range, Int) -> List String
+||| Each line is wrapped in <span id="L<n>"> (1-based), the anchor
+||| granularity links target.
+renderLines : (lineNo : Int) -> List String -> List (Range, Int, Maybe String) -> List String
 renderLines _ [] _ = []
 renderLines lineNo (l :: ls) toks =
   let (html, leftover) = renderLine lineNo 0 (unpack l) toks
-  in html :: renderLines (lineNo + 1) ls leftover
+  in ("<span id=\"L" ++ show (lineNo + 1) ++ "\">" ++ html ++ "</span>")
+       :: renderLines (lineNo + 1) ls leftover
 
 ||| Same classification a `semanticTokens/full` response carries
 ||| (Nova.LSP.SemanticTokens.getSemanticTokens), just emitted as HTML
-||| spans instead of the LSP wire format's delta-encoded ints.
-renderSource : String -> List (Range, TokenKind) -> String
-renderSource source rawToks =
-  let sorted = sortTokens (map (\(r, k) => (r, tokenKindIndex k)) rawToks)
+||| spans instead of the LSP wire format's delta-encoded ints —
+||| plus a per-token href from the resolver.
+renderSource : String -> List (Range, TokenKind) -> (Range -> TokenKind -> Maybe String) -> String
+renderSource source rawToks hrefOf =
+  let sorted = sortTokens (map (\(r, k) => (r, tokenKindIndex k, hrefOf r k)) rawToks)
   in joinBy "\n" (renderLines 0 (lines source) sorted)
 
 htmlPage : (title : String) -> String -> String
@@ -110,6 +136,30 @@ baseNameOf path =
     then pack (reverse (drop 5 (reverse (unpack name))))
     else name
 
+||| The static go-to-definition resolver for one page: written name →
+||| qualified (the module's own aliases, Nova.LSP.Definitions), then
+||| the program-wide index gives (file, item range) → an href to the
+||| defining line; a miss that names a loaded module links to its
+||| page instead (import heads).
+hrefResolver : (path : String) -> (lns : List String)
+            -> SortedMap String String
+            -> SortedMap String (String, NRange)
+            -> SortedMap String ()
+            -> Range -> TokenKind -> Maybe String
+hrefResolver path lns aliases index pages r k =
+  if not (isNameKind k) then Nothing else
+  let txt = sliceRange lns r in
+  if txt == "" then Nothing else
+  let q = fromMaybe txt (SortedMap.lookup txt aliases) in
+  case SortedMap.lookup q index of
+    Just (file, MkRange (MkPosition dl _) _) =>
+      let frag = "#L" ++ show (dl + 1) in
+      Just (if file == path then frag else baseNameOf file ++ ".html" ++ frag)
+    Nothing =>
+      case SortedMap.lookup txt pages of
+        Just () => Just (txt ++ ".html")
+        Nothing => Nothing
+
 ||| Load and render one .nova file to a
 ||| standalone HTML page. Errors (parse/load failure) are reported,
 ||| not thrown — one bad file shouldn't abort the whole batch.
@@ -121,7 +171,15 @@ renderFile path = do
     | Nothing => pure (Left "loadProgram returned no modules for \{path}")
   Right source <- readFile path
     | Left err => pure (Left "cannot read \{path}: \{show err}")
+  let lns = lines source
+  let aliases = SortedMap.fromList (localAliases root)
+  let index = SortedMap.fromList
+                (map (\(n, f, rng) => (n, (f, rng))) (buildIndex path units))
+  let pages = SortedMap.fromList
+                (mapMaybe (\u => if u.mname == "" then Nothing
+                                  else Just (u.mname, ())) units)
   let body = renderSource source (toList root.mtokens)
+               (hrefResolver path lns aliases index pages)
   let base = baseNameOf path
   pure (Right (base, htmlPage base body))
 

--- a/src/idris/Nova/LSP/Definitions.idr
+++ b/src/idris/Nova/LSP/Definitions.idr
@@ -84,6 +84,7 @@ buildIndex rootPath = concatMap (moduleEntries rootPath (dirOf rootPath))
 
 ||| Mirrors `Nova.Elaboration.resolveSigName`'s `vis`: the module's own
 ||| items (by their bare name) plus its imports' opened aliases.
+export
 localAliases : ModUnit -> List (String, String)
 localAliases unit =
   concatMap (\(_, item) => map (\n => (n, qualify unit.mname n)) (itemNames item)) unit.mitems
@@ -100,6 +101,7 @@ resolveReference root index written =
   let qualified = fromMaybe written (lookup written (localAliases root)) in
   map (\(_, file, rng) => (file, rng)) (List.find (\(n, _, _) => n == qualified) index)
 
+export
 isNameKind : TokenKind -> Bool
 isNameKind Identifier = True
 isNameKind Operator   = True
@@ -110,6 +112,7 @@ contains (MkRange s e) p =
   (p.line > s.line || (p.line == s.line && p.column >= s.column)) &&
   (p.line < e.line || (p.line == e.line && p.column < e.column))
 
+export
 sliceRange : List String -> NRange -> String
 sliceRange lns (MkRange (MkPosition sl sc) (MkPosition el ec)) =
   if sl /= el

--- a/tools/nova-docs.css
+++ b/tools/nova-docs.css
@@ -33,6 +33,11 @@ pre {
   background:var(--panel); border:1px solid var(--hair); border-radius:6px;
   padding:1rem; overflow-x:auto;
 }
+code.nova-source a { color:inherit; text-decoration:none;
+  border-bottom:1px dotted transparent; }
+code.nova-source a:hover { border-bottom-color:currentColor; }
+code.nova-source span[id]:target { background:var(--panel);
+  box-shadow:0 0 0 3px var(--panel); border-radius:2px; }
 code.nova-source {
   font-family:ui-monospace,"SF Mono",Menlo,Consolas,monospace;
   font-size:14px; line-height:1.5; white-space:pre;
@@ -42,7 +47,3 @@ code.nova-source {
 .tok-operator   { color:var(--nova); }
 .tok-number     { color:var(--natc); }
 .tok-comment    { color:var(--faint); font-style:italic; }
-.tok-unsolved_meta {
-  color:var(--meta); text-decoration:underline dotted var(--meta);
-}
-.tok-solved_meta { color:var(--tos); }


### PR DESCRIPTION
## What

Go-to-definition for the rendered `.nova` pages, statically. Every resolvable identifier/operator token becomes a link to its defining item — same page as `#L37`, cross-module as `nat.html#L12` — and every rendered line carries an `id="L<n>"` anchor (1-based). A written name that resolves to no item but names a loaded module links to that module's page, so `import` heads navigate too.

## How

Resolution is the same machinery the LSP's definition request uses — `Nova.LSP.Definitions`' `buildIndex`/`localAliases` pipeline, purely syntactic over the loaded `ModUnit`s, no elaboration — so the web pages and the editor agree by construction, caveat included (a local shadowing a global links to the global). The renderer builds the maps once per page and resolves per token; three small helpers in `Definitions` gained `export`.

CSS: token links keep their token's color (dotted underline on hover), the jumped-to line highlights via `:target`, and the removed semantic-token legend's dead `tok-*_meta` rules are swept.

## Verification

Full corpus render: 49 pages, 14,230 links, **zero broken** — every href checked against the target page's line anchors; `natMonoid.html`'s `plusAssoc` lands on `nat.html#L14`, the `def plusAssoc` line. 138/138 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
