### PR TITLE
UIP for the Id QIIT, via its eliminator

### DIFF
--- a/src/nova/all.nova
+++ b/src/nova/all.nova
@@ -52,5 +52,6 @@ import stream
 import streamEq
 import streamBisim
 import sum
+import uip
 import vectByInd
 import vectByIndAppend

--- a/src/nova/uip.nova
+++ b/src/nova/uip.nova
@@ -1,0 +1,29 @@
+-- UIP for the identity QIIT, via its eliminator. In intensional MLTT
+-- J cannot prove UIP (Hofmann–Streicher); here it can, because the
+-- would-be-ill-typed motive "w ≡ refl a u ∈ El (Id a u v)" becomes
+-- well-typed under a reflected index equation — the motive carries
+-- that equation INSIDE a squashed Π, so its binder is in scope (and
+-- reflected) exactly while the codomain is typed.
+import id (Id, refl, IdElimP, idToEq)
+import equality (sym, trans)
+
+-- canonicity: under the index equation (always derivable from the
+-- proof itself, by idToEq), every proof of Id a x y IS refl.
+def idCanon : (a : 𝕌) (x : El a) (y : El a) (p : El (Id a x y)) (h : x ≡ y ∈ El a) →
+              p ≡ refl a x ∈ El (Id a x y) ≔
+  λa. λx. λy. λp. λh.
+    squash-elim
+      (IdElimP a
+        (λu. λv. λw. ∥(k : u ≡ v ∈ El a) → (w ≡ refl a u ∈ El (Id a u v))∥)
+        (λu. ⋆ (λk. ⋆))
+        x y p)
+      (f. f h)
+
+-- uniqueness of identity proofs: both are refl, by canonicity.
+def uip : (a : 𝕌) (x : El a) (y : El a) (p : El (Id a x y)) (q : El (Id a x y)) →
+          p ≡ q ∈ El (Id a x y) ≔
+  λa. λx. λy. λp. λq.
+    let h ≔ idToEq a x y p in
+    trans (Id a x y) p (refl a x) q
+      (idCanon a x y p h)
+      (sym (Id a x y) q (refl a x) (idCanon a x y q h))


### PR DESCRIPTION
Adds \`src/nova/uip.nova\` to the corpus: uniqueness of identity proofs for the identity family \`Id\` (the small QIIT from \`id.nova\`), proven with \`IdElimP\` — no new rules, no kernel changes.

The classical obstruction (Hofmann–Streicher) is that the J-motive \`w ≡ refl u\` is ill-typed: \`refl u : Id u u\` while \`w : Id u v\`. Equality reflection dissolves it: the motive carries the index equation inside a squashed dependent Π,

    λu. λv. λw. ∥(k : u ≡ v ∈ El a) → (w ≡ refl a u ∈ El (Id a u v))∥

so \`k\` is in scope — and reflected — exactly while the codomain is typed, putting \`refl a u\` at \`El (Id a u v)\`. The refl-method is \`⋆ (λk. ⋆)\`, \`ElimP\` asks no coherences, and at the use site the hypothesis comes for free from the eliminee itself via \`idToEq\`. \`uip\` then composes the two canonicity instances with \`trans\`/\`sym\` (a bare \`⋆\` after let-binding them trips the kernel's dependent-motive step approximation, so the composition is explicit).

This is another instance of the A5 route (docs/NovaKernel.txt): a uniqueness-flavored fact about a QIIT proven as an ordinary eliminator lemma at an equality motive, with no kernel η certificate.

\`all.nova\` gains the corresponding import; \`./test.sh\` is green (138/138 tests, 48/48 elaborations).