### PR TITLE
Prf ⊥ does yield data: prop.absurd and absurdD

### DIFF
--- a/docs/ProvingFeedback.md
+++ b/docs/ProvingFeedback.md
@@ -611,11 +611,15 @@ diagnostic is `Prf (prop.⊥) ≐ 𝟘 type`. The idiom is
 `squash-elim h (t. 𝟘-elim t)`, and it is needed at every refutation.
 **Resolved:** `prop.nova` now has `absurdP : (p : Ω) → Prf ⊥ → Prf p`.
 
-Note there can be no `El A`-valued counterpart: `el-squash-e-prf`
-reaches only further *propositions*, so a `Prf ⊥` can never produce
-data — for that one needs a `𝟘` itself. Refutations that must yield an
-element (a `⊎`-branch, say) have to keep the raw `𝟘` around, as
-`nzOfPairD` does with `zNotS`.
+There is no `El A`-valued counterpart *of that shape*: `el-squash-e-prf`
+reaches only further *propositions*, so no elimination of the proof
+produces data. ⊥ itself is not data-inert, though — `prop.absurd :
+Prf ⊥ → 𝟘` goes around the eliminator (⊥ proves the false equation
+`Z ≡ S Z ∈ ℕ`, `el-reflect` makes it judgemental, `isZeroCode`
+transports `()` from `𝟙` into `𝟘`), and `prop.absurdD : (A : 𝕌) →
+Prf ⊥ → El A` follows by `𝟘-elim`. So a refutation that must yield an
+element can either keep the raw `𝟘` around, as `nzOfPairD` does with
+`zNotS`, or call `absurdD`.
 
 ### F-3. `⋆` does not prove Σ-shaped squashes
 

--- a/src/nova/eqNat.nova
+++ b/src/nova/eqNat.nova
@@ -1,5 +1,5 @@
 import prelude (constP)
-import prop (⊤, ⊥, ↔, iffIntro, reflectSquash)
+import prop (⊤, ⊥, ↔, iffIntro, reflectSquash, isZeroCode)
 import equality (cong, sym, transport)
 
 -- Observational equality of natural numbers, defined in Ω, and its
@@ -31,9 +31,9 @@ def eqNSound : (n : ℕ) → (m : ℕ) → Prf (EqN n m) → n ≡ m ∈ ℕ usi
       m)
     n
 
--- ℕ has no confusion between Z and S _: transporting the "is-Z" code
--- along a bad Z ≡ S j equation lands a 𝟙-witness in 𝟘
-def isZeroCode : ℕ → 𝕌 ≔ λn. ℕ-elim (_. 𝕌) 𝟙 (n ih. 𝟘) n
+-- ℕ has no confusion between Z and S _: transporting prop.nova's
+-- "is-Z" code along a bad Z ≡ S j equation lands a 𝟙-witness in 𝟘
+-- (prop.absurd is the j ≔ Z instance, composed with absurdP)
 def zNotS : (j : ℕ) → (Z ≡ S j ∈ ℕ) → 𝟘 ≔
   λj. λh. transport ℕ isZeroCode Z (S j) h ()
 

--- a/src/nova/field.nova
+++ b/src/nova/field.nova
@@ -6,8 +6,10 @@ import group (IsGroup)
 -- multiplicative monoid (both codes, so both layer directly),
 -- commutativity of each, distributivity, and the two components the
 -- Ω-world could not put in a code — stated with Id they can be:
---   * nontriviality is a FUNCTION Id F one zero → 𝟘 (an Id-refutation
---     is data, where Prf ⊥ could never yield an element of 𝟘);
+--   * nontriviality is a FUNCTION Id F one zero → 𝟘 — an Id-refutation
+--     is data, and stays inside 𝕌, where an Ω-valued ¬ (one ≡ zero)
+--     could not go (prop.absurd shows a Prf ⊥ can still be turned into
+--     a 𝟘, but only by reflecting an equation, not as a code);
 --   * inverses are an UNSQUASHED Σ-code — "here is the inverse", not
 --     "one exists" — available to any nonzero x, with nonzero-ness
 --     itself an Id-refutation.

--- a/src/nova/prop.nova
+++ b/src/nova/prop.nova
@@ -1,3 +1,5 @@
+import equality (transport)
+
 -- Ω, the universe of mere propositions (docs/NovaFoundation.txt).
 --
 -- Propositions are Ω-valued; Prf decodes one to a (realizer-irrelevant)
@@ -67,12 +69,31 @@ def impApply : (p : Ω) (q : Ω) → Prf (p ⊃ q) → Prf p → Prf q ≔
   λp. λq. λh. λx. squash-elim h (f. f x)
 
 -- ⊥ ≜ ∥𝟘∥, so 𝟘-elim cannot consume a Prf ⊥ directly: a refutation
--- has to unsquash first. absurdP names that step. There is deliberately
--- no El A-valued counterpart: el-squash-e-prf reaches only further
--- PROPOSITIONS, so a Prf ⊥ can never produce data — for that one needs
--- a 𝟘 itself, which 𝟘-elim already consumes.
+-- has to unsquash first. absurdP names that step, and it is as far as
+-- ELIMINATING the proof goes — el-squash-e-prf reaches only further
+-- PROPOSITIONS, so there is no El A-valued counterpart of this shape.
 def absurdP : (p : Ω) → Prf ⊥ → Prf p ≔
   λp. λh. squash-elim h (x. 𝟘-elim x)
+
+-- That limit is a limit on the ELIMINATOR, not on ⊥: a Prf ⊥ does
+-- yield data — by going around it. ⊥ proves every proposition and
+-- equations ARE propositions (≡ is Ω-valued), so it proves the false
+-- Z ≡ S Z ∈ ℕ; el-reflect makes that equation JUDGEMENTAL, hence
+-- isZeroCode Z ≐ isZeroCode (S Z), i.e. 𝟙 ≐ 𝟘, and () crosses.
+--
+-- This is not proof relevance sneaking back in: nothing inspects h's
+-- realizer. What leaves Ω is the mere EXISTENCE of a proof, which
+-- el-reflect turns into a judgemental equation, and judgemental
+-- equations act on types. Consistency is untouched — Prf ⊥ is empty,
+-- so absurd is never applied.
+def isZeroCode : ℕ → 𝕌 ≔ λn. ℕ-elim (_. 𝕌) 𝟙 (n ih. 𝟘) n
+def absurd : Prf ⊥ → 𝟘 ≔
+  λh. transport ℕ isZeroCode Z (S Z) (absurdP (Z ≡ S Z ∈ ℕ) h) ()
+
+-- …and hence the El A-valued eliminator the paragraph above says no
+-- ELIMINATION of a Prf ⊥ can give: 𝟘-elim consumes the escaped 𝟘.
+def absurdD : (A : 𝕌) → Prf ⊥ → El A ≔
+  λA. λh. 𝟘-elim (absurd h)
 
 def orInl : (p : Ω) (q : Ω) → Prf p → Prf (p ∨ q) ≔
   λp. λq. λx. ⋆ (λr. λf. λg. f x)


### PR DESCRIPTION
`absurdP : (p : Ω) → Prf ⊥ → Prf p` is the limit of *eliminating* a proof of ⊥ — `el-squash-e-prf` reaches only further propositions. The corpus took that to mean a `Prf ⊥` can never produce data. It can, by going around the eliminator:

```
def isZeroCode : ℕ → 𝕌 ≔ λn. ℕ-elim (_. 𝕌) 𝟙 (n ih. 𝟘) n
def absurd : Prf ⊥ → 𝟘 ≔
  λh. transport ℕ isZeroCode Z (S Z) (absurdP (Z ≡ S Z ∈ ℕ) h) ()
def absurdD : (A : 𝕌) → Prf ⊥ → El A ≔
  λA. λh. 𝟘-elim (absurd h)
```

⊥ proves every proposition and equations *are* propositions, so it proves the false `Z ≡ S Z ∈ ℕ`; `el-reflect` makes that equation judgemental, hence `isZeroCode Z ≐ isZeroCode (S Z)`, i.e. `𝟙 ≐ 𝟘`, and `()` crosses.

This is not proof relevance sneaking back in: nothing inspects the realizer of `h`. What leaves Ω is the mere *existence* of a proof, which `el-reflect` turns into a judgemental equation, and judgemental equations act on types. Consistency is untouched — `Prf ⊥` is empty, so neither function is ever applied.

Also here:

- `isZeroCode` moves from `eqNat.nova` to `prop.nova`, its first user; `zNotS` now imports it (it is the `j ≔ Z` instance of the same transport). `prop.nova` gains one import, `equality (transport)` — no cycle, `equality.nova` imports nothing.
- The notes in `prop.nova`, `field.nova` and `docs/ProvingFeedback.md` F-2 that claimed a `Prf ⊥` could never yield an element of `𝟘` are corrected to say what actually holds: no *elimination* of the proof produces data. `field.nova`'s nontriviality component is rejustified by `Id` staying inside 𝕌, which is the real reason it is stated with `Id`.